### PR TITLE
Make ApacheSecureAuth configurable via environment variables (LDAP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,27 @@ New options are added on a regular basis.
     -   `./gnupg`: `/var/www/MISP/.gnupg/`
 -   If you need to automatically run additional steps each time the container starts, create a new file `files/customize_misp.sh`, and replace the variable `${CUSTOM_PATH}` inside `docker-compose.yml` with its parent path.
 
+## Installing custom root CA certificates
+
+Custom root CA certificates can be mounted under `/usr/local/share/ca-certificates` and will be installed during the `misp-core` container start.
+
+**Note:** It is important to have the .crt extension on the file, otherwise it will not be processed.
+
+```yaml
+  misp-core:
+    # ...
+    volumes:
+      - "./configs/:/var/www/MISP/app/Config/"
+      - "./logs/:/var/www/MISP/app/tmp/logs/"
+      - "./files/:/var/www/MISP/app/files/"
+      - "./ssl/:/etc/nginx/certs/"
+      - "./gnupg/:/var/www/MISP/.gnupg/"
+      # customize by replacing ${CUSTOM_PATH} with a path containing 'files/customize_misp.sh'
+      # - "${CUSTOM_PATH}/:/custom/"
+      # mount custom ca root certificates
+      - "./rootca.pem:/usr/local/share/ca-certificates/rootca.crt"
+```
+
 ## Troubleshooting
 
 -   Make sure you run a fairly recent version of Docker and Docker Compose (if in doubt, update following the steps outlined in https://docs.docker.com/engine/install/ubuntu/)

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -169,6 +169,8 @@ FROM "${DOCKER_HUB_PROXY}debian:bullseye-slim"
         php-gd \
         php-fpm \
         php-zip \
+        php-ldap \
+        libldap-common \
         librdkafka1 \
         libbrotli1 \
         libsimdjson5 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,8 @@ services:
       - "./gnupg/:/var/www/MISP/.gnupg/"
       # customize by replacing ${CUSTOM_PATH} with a path containing 'files/customize_misp.sh'
       # - "${CUSTOM_PATH}/:/custom/"
+      # mount custom ca root certificates
+      # - "./rootca.pem:/usr/local/share/ca-certificates/rootca.crt"
     environment:
       - "BASE_URL=${BASE_URL}"
       - "CRON_USER_ID=${CRON_USER_ID}"
@@ -69,7 +71,7 @@ services:
       - "ADMIN_KEY=${ADMIN_KEY}"
       - "ADMIN_ORG=${ADMIN_ORG}"
       - "GPG_PASSPHRASE=${GPG_PASSPHRASE}"
-      # authentication settings
+      # OIDC authentication settings
       - "OIDC_ENABLE=${OIDC_ENABLE}"
       - "OIDC_PROVIDER_URL=${OIDC_PROVIDER_URL}"
       - "OIDC_CLIENT_ID=${OIDC_CLIENT_ID}"
@@ -77,6 +79,23 @@ services:
       - "OIDC_ROLES_PROPERTY=${OIDC_ROLES_PROPERTY}"
       - "OIDC_ROLES_MAPPING=${OIDC_ROLES_MAPPING}"
       - "OIDC_DEFAULT_ORG=${OIDC_DEFAULT_ORG}"
+      # LDAP authentication settings
+      - "LDAP_ENABLE=${LDAP_ENABLE}"
+      - "LDAP_APACHE_ENV=${LDAP_APACHE_ENV}"
+      - "LDAP_SERVER=${LDAP_SERVER}"
+      - "LDAP_STARTTLS=${LDAP_STARTTLS}"
+      - "LDAP_READER_USER=${LDAP_READER_USER}"
+      - "LDAP_READER_PASSWORD=${LDAP_READER_PASSWORD}"
+      - "LDAP_DN=${LDAP_DN}"
+      - "LDAP_SEARCH_FILTER=${LDAP_SEARCH_FILTER}"
+      - "LDAP_SEARCH_ATTRIBUTE=${LDAP_SEARCH_ATTRIBUTE}"
+      - "LDAP_FILTER=${LDAP_FILTER}"
+      - "LDAP_DEFAULT_ROLE_ID=${LDAP_DEFAULT_ROLE_ID}"
+      - "LDAP_DEFAULT_ORG=${LDAP_DEFAULT_ORG}"
+      - "LDAP_EMAIL_FIELD=${LDAP_EMAIL_FIELD}"
+      - "LDAP_OPT_PROTOCOL_VERSION=${LDAP_OPT_PROTOCOL_VERSION}"
+      - "LDAP_OPT_NETWORK_TIMEOUT=${LDAP_OPT_NETWORK_TIMEOUT}"
+      - "LDAP_OPT_REFERRALS=${LDAP_OPT_REFERRALS}"
       # sync server settings (see https://www.misp-project.org/openapi/#tag/Servers for more options)
       - "SYNCSERVERS=${SYNCSERVERS}"
       - |

--- a/template.env
+++ b/template.env
@@ -96,3 +96,23 @@ SYNCSERVERS_1_KEY=
 # OIDC_ROLES_PROPERTY="roles"
 # OIDC_ROLES_MAPPING={"admin": "1","sync-user": "5"}
 # OIDC_DEFAULT_ORG=
+
+# Enable LDAP (using the ApacheSecureAuth component) authentication, according to https://github.com/MISP/MISP/issues/6189
+# NOTE: Once you enable LDAP authentication with the ApacheSecureAuth component, users should not be able to control the HTTP header configured in LDAP_APACHE_ENV (e.g. REMOTE_USER).
+#       This means you must not allow direct access to MISP.
+# LDAP_ENABLE=true
+# LDAP_APACHE_ENV="REMOTE_USER"
+# LDAP_SERVER="ldap://your_domain_controller"
+# LDAP_STARTTLS=true
+# LDAP_READER_USER="CN=service_account_name,OU=Users,DC=domain,DC=net"
+# LDAP_READER_PASSWORD="password"
+# LDAP_DN="OU=Users,DC=domain,DC=net"
+# LDAP_SEARCH_FILTER=""
+# LDAP_SEARCH_ATTRIBUTE="uid"
+# LDAP_FILTER="[\"mail\", \"uid\", \"cn\" ]"
+# LDAP_DEFAULT_ROLE_ID="3"
+# LDAP_DEFAULT_ORG="1"
+# LDAP_EMAIL_FIELD="[\"mail\"]"
+# LDAP_OPT_PROTOCOL_VERSION="3"
+# LDAP_OPT_NETWORK_TIMEOUT="-1"
+# LDAP_OPT_REFERRALS=false


### PR DESCRIPTION
I am trying to migrate an existing MISP deployment to the `misp-docker` containers.
Currently I use the `ApacheSecureAuth` Component and an Apache reverse proxy for LDAP authentication. (as described here: https://github.com/MISP/MISP/issues/6189)

For this to work I need the LDAP dependencies in the image and some config values in the `config.php`.

I still need to do some more testing. 


