### PR TITLE
Fix #16 Remote Servers Certificates - Persistence Issue

### DIFF
--- a/core/files/entrypoint_nginx.sh
+++ b/core/files/entrypoint_nginx.sh
@@ -147,8 +147,13 @@ EOT
 
 update_misp_data_files(){
     for DIR in $(ls /var/www/MISP/app/files.dist); do
-        echo "... rsync -azh --delete \"/var/www/MISP/app/files.dist/$DIR\" \"/var/www/MISP/app/files/\""
-        rsync -azh --delete "/var/www/MISP/app/files.dist/$DIR" "/var/www/MISP/app/files/"
+        if [ "$DIR" = "certs" ]; then
+            echo "... rsync -azh --delete \"/var/www/MISP/app/files.dist/$DIR\" \"/var/www/MISP/app/files/\""
+            rsync -azh "/var/www/MISP/app/files.dist/$DIR" "/var/www/MISP/app/files/"
+        else
+            echo "... rsync -azh --delete \"/var/www/MISP/app/files.dist/$DIR\" \"/var/www/MISP/app/files/\""
+            rsync -azh --delete "/var/www/MISP/app/files.dist/$DIR" "/var/www/MISP/app/files/"
+        fi
     done
 }
 

--- a/core/files/entrypoint_nginx.sh
+++ b/core/files/entrypoint_nginx.sh
@@ -148,7 +148,7 @@ EOT
 update_misp_data_files(){
     for DIR in $(ls /var/www/MISP/app/files.dist); do
         if [ "$DIR" = "certs" ]; then
-            echo "... rsync -azh --delete \"/var/www/MISP/app/files.dist/$DIR\" \"/var/www/MISP/app/files/\""
+            echo "... rsync -azh \"/var/www/MISP/app/files.dist/$DIR\" \"/var/www/MISP/app/files/\""
             rsync -azh "/var/www/MISP/app/files.dist/$DIR" "/var/www/MISP/app/files/"
         else
             echo "... rsync -azh --delete \"/var/www/MISP/app/files.dist/$DIR\" \"/var/www/MISP/app/files/\""


### PR DESCRIPTION
### What does it do?
The change fixed #16 
### Expected behavior
The certificates should remain in `/var/www/MISP/app/files/certs/` after rebooting or updating the MISP Docker container.