### PR TITLE
Add Subject Alternative Names to self-siged certificate

### DIFF
--- a/core/files/entrypoint_nginx.sh
+++ b/core/files/entrypoint_nginx.sh
@@ -248,7 +248,8 @@ init_nginx() {
     
     if [[ ! -f /etc/nginx/certs/cert.pem || ! -f /etc/nginx/certs/key.pem ]]; then
         echo "... generating new self-signed TLS certificate"
-        openssl req -x509 -subj '/CN=localhost' -nodes -newkey rsa:4096 -keyout /etc/nginx/certs/key.pem -out /etc/nginx/certs/cert.pem -days 365
+        openssl req -x509 -subj '/CN=localhost' -nodes -newkey rsa:4096 -keyout /etc/nginx/certs/key.pem -out /etc/nginx/certs/cert.pem -days 365 \
+            -addext "subjectAltName = DNS:localhost, IP:127.0.0.1, IP:::1"
     else
         echo "... TLS certificates found"
     fi


### PR DESCRIPTION
When using the self-signed certificate generated by openssl for nginx, only the Common Name is used for validating requests.
This behaviour is deprecated and will be removed from certain libraries in the future:
[Feature: Remove support for common names in certificates](https://github.com/urllib3/urllib3/issues/497)
[Remove support for common names in certificates; only support Subject Alt Names](https://issues.chromium.org/issues/40078252)

I have noticed this while using the REST API with the python requests library, which generated the following warning for each request:
![python-requests-warning](https://github.com/MISP/misp-docker/assets/46527450/cb1ebedd-9000-4cf5-9d1e-5415f78cad1a)

This commit does not delete existing certificates, only adds the SAN extension to newly generated ones.
I included:
 - localhost
 - 127.0.0.1
 - ::1

Tested on debian 12 using the latest docker engine by docker.com