### PR TITLE
Add healthchecks to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,12 @@ services:
 
   redis:
     image: eqalpha/keydb:x86_64_v6.3.4
+    healthcheck:
+      test: keydb-cli ping || exit 1
+      interval: 2s
+      timeout: 1s
+      retries: 3
+      start_period: 30s
 
   db:
     # We use MariaDB because it supports ARM and has the expected collations
@@ -27,6 +33,12 @@ services:
       - mysql_data:/var/lib/mysql
     cap_add:
       - SYS_NICE  # CAP_SYS_NICE Prevent runaway mysql log
+    healthcheck:
+      test: mysqladmin --user=$$MYSQL_USER --password=$$MYSQL_PASSWORD status
+      interval: 2s
+      timeout: 1s
+      retries: 3
+      start_period: 30s
 
   misp-core:
     image: ghcr.io/misp/misp-docker/misp-core:latest
@@ -46,8 +58,16 @@ services:
           - PYPI_CYBOX_VERSION=${PYPI_CYBOX_VERSION}
           - PYPI_PYMISP_VERSION=${PYPI_PYMISP_VERSION}
     depends_on:
-      - redis
-      - db
+      redis:
+        condition: service_healthy
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: curl -ks https://localhost/users/login > /dev/null || exit 1
+      interval: 2s
+      timeout: 1s
+      retries: 3
+      start_period: 30s
     ports:
       - "80:80"
       - "443:443"
@@ -126,7 +146,8 @@ services:
     environment:
       - "REDIS_BACKEND=redis"
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy
 
 volumes:
     mysql_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,9 @@ services:
       - "SMARTHOST_ALIASES=${SMARTHOST_ALIASES}"
 
   redis:
-    image: eqalpha/keydb:x86_64_v6.3.4
+    image: valkey/valkey:7.2
     healthcheck:
-      test: keydb-cli ping || exit 1
+      test: valkey-cli ping || exit 1
       interval: 2s
       timeout: 1s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "SMARTHOST_ALIASES=${SMARTHOST_ALIASES}"
 
   redis:
-    image: redis:7.2
+    image: eqalpha/keydb:x86_64_v6.3.4
 
   db:
     # We use MariaDB because it supports ARM and has the expected collations


### PR DESCRIPTION
Hello,

here's a small PR to replace redis with keydb due to redis license changes and to add healthchecks to services.