### PR TITLE
Add AadAuth support in configure_misp.sh

### DIFF
--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -157,6 +157,61 @@ set_up_ldap() {
     }" > /dev/null
 }
 
+set_up_aad() {
+    if [[ "$AAD_ENABLE" != "true" ]]; then
+        echo "... Entra (AzureAD) authentication disabled"
+        return
+    fi
+
+    # Check required variables
+    check_env_vars AAD_CLIENT_ID AAD_TENANT_ID AAD_CLIENT_SECRET BASE_URL
+
+    # Configure unset optional AAD environment variables to default values
+    [ -z "$AAD_REDIRECT_URI" ] && AAD_REDIRECT_URI="${BASE_URL}/users/login"
+    [ -z "$AAD_PROVIDER" ] && AAD_PROVIDER=https://login.microsoftonline.com/
+    [ -z "$AAD_PROVIDER_USER" ] && AAD_PROVIDER_USER=https://graph.microsoft.com/
+    [ -z "$AAD_MISP_USER" ] && AAD_MISP_USER="Misp Users"
+    [ -z "$AAD_MISP_ORGADMIN" ] && AAD_MISP_ORGADMIN="Misp Org Admins"
+    [ -z "$AAD_MISP_SITEADMIN" ] && AAD_MISP_SITEADMIN="Misp Site Admins"
+    [ -z "$AAD_CHECK_GROUPS" ] && AAD_CHECK_GROUPS=false
+
+    # Note: Not necessary to edit bootstrap.php to load AadAuth Cake plugin because 
+    # existing loadAll() call in bootstrap.php already loads all available Cake plugins
+
+    # Set auth mechanism to AAD in config.php file
+    sudo -u www-data php /var/www/MISP/tests/modify_config.php modify "{
+        \"Security\": {
+            \"auth\": [\"AadAuth.AadAuthenticate\"]
+        }
+    }" > /dev/null
+
+    echo "hello"
+    # Configure AAD auth settings from environment variables in config.php file
+    sudo -u www-data php /var/www/MISP/tests/modify_config.php modify "{
+        \"AadAuth\": {
+            \"client_id\": \"${AAD_CLIENT_ID}\",
+            \"ad_tenant\": \"${AAD_TENANT_ID}\",
+            \"client_secret\": \"${AAD_CLIENT_SECRET}\",
+            \"redirect_uri\": \"${AAD_REDIRECT_URI}\",
+            \"auth_provider\": \"${AAD_PROVIDER}\",
+            \"auth_provider_user\": \"${AAD_PROVIDER_USER}\",
+            \"misp_user\": \"${AAD_MISP_USER}\",
+            \"misp_orgadmin\": \"${AAD_MISP_ORGADMIN}\",
+            \"misp_siteadmin\": \"${AAD_MISP_SITEADMIN}\",
+            \"check_ad_groups\": ${AAD_CHECK_GROUPS}
+        }
+    }" > /dev/null
+
+    # Disable self-management, username change, and password change to prevent users from circumventing AAD login flow
+    # Recommended per https://github.com/MISP/MISP/blob/2.4/app/Plugin/AadAuth/README.md
+    sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q "MISP.disableUserSelfManagement" true
+    sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q "MISP.disable_user_login_change" true
+    sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q "MISP.disable_user_password_change" true
+
+    # Disable password confirmation as stated at https://github.com/MISP/MISP/issues/8116
+    sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q "Security.require_password_confirmation" false
+}
+
 apply_updates() {
     # Disable weird default
     sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q "Plugin.ZeroMQ_enable" false
@@ -322,6 +377,8 @@ echo "MISP | Update components ..." && update_components
 echo "MISP | Set Up OIDC ..." && set_up_oidc
 
 echo "MISP | Set Up LDAP ..." && set_up_ldap
+
+echo "MISP | Set Up AAD ..." && set_up_aad
 
 echo "MISP | Mark instance live"
 sudo -u www-data /var/www/MISP/app/Console/cake Admin live 1

--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -185,7 +185,6 @@ set_up_aad() {
         }
     }" > /dev/null
 
-    echo "hello"
     # Configure AAD auth settings from environment variables in config.php file
     sudo -u www-data php /var/www/MISP/tests/modify_config.php modify "{
         \"AadAuth\": {

--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -164,16 +164,7 @@ set_up_aad() {
     fi
 
     # Check required variables
-    check_env_vars AAD_CLIENT_ID AAD_TENANT_ID AAD_CLIENT_SECRET BASE_URL
-
-    # Configure unset optional AAD environment variables to default values
-    [ -z "$AAD_REDIRECT_URI" ] && AAD_REDIRECT_URI="${BASE_URL}/users/login"
-    [ -z "$AAD_PROVIDER" ] && AAD_PROVIDER="https://login.microsoftonline.com/"
-    [ -z "$AAD_PROVIDER_USER" ] && AAD_PROVIDER_USER="https://graph.microsoft.com/"
-    [ -z "$AAD_MISP_USER" ] && AAD_MISP_USER="Misp Users"
-    [ -z "$AAD_MISP_ORGADMIN" ] && AAD_MISP_ORGADMIN="Misp Org Admins"
-    [ -z "$AAD_MISP_SITEADMIN" ] && AAD_MISP_SITEADMIN="Misp Site Admins"
-    [ -z "$AAD_CHECK_GROUPS" ] && AAD_CHECK_GROUPS=false
+    check_env_vars AAD_CLIENT_ID AAD_TENANT_ID AAD_CLIENT_SECRET AAD_REDIRECT_URI AAD_PROVIDER AAD_PROVIDER_USER AAD_MISP_ORGADMIN AAD_MISP_SITEADMIN AAD_CHECK_GROUPS
 
     # Note: Not necessary to edit bootstrap.php to load AadAuth Cake plugin because 
     # existing loadAll() call in bootstrap.php already loads all available Cake plugins

--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -168,8 +168,8 @@ set_up_aad() {
 
     # Configure unset optional AAD environment variables to default values
     [ -z "$AAD_REDIRECT_URI" ] && AAD_REDIRECT_URI="${BASE_URL}/users/login"
-    [ -z "$AAD_PROVIDER" ] && AAD_PROVIDER=https://login.microsoftonline.com/
-    [ -z "$AAD_PROVIDER_USER" ] && AAD_PROVIDER_USER=https://graph.microsoft.com/
+    [ -z "$AAD_PROVIDER" ] && AAD_PROVIDER="https://login.microsoftonline.com/"
+    [ -z "$AAD_PROVIDER_USER" ] && AAD_PROVIDER_USER="https://graph.microsoft.com/"
     [ -z "$AAD_MISP_USER" ] && AAD_MISP_USER="Misp Users"
     [ -z "$AAD_MISP_ORGADMIN" ] && AAD_MISP_ORGADMIN="Misp Org Admins"
     [ -z "$AAD_MISP_SITEADMIN" ] && AAD_MISP_SITEADMIN="Misp Site Admins"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,17 @@ services:
       - "LDAP_OPT_PROTOCOL_VERSION=${LDAP_OPT_PROTOCOL_VERSION}"
       - "LDAP_OPT_NETWORK_TIMEOUT=${LDAP_OPT_NETWORK_TIMEOUT}"
       - "LDAP_OPT_REFERRALS=${LDAP_OPT_REFERRALS}"
+      # AAD authentication settings
+      - "AAD_CLIENT_ID=${AAD_CLIENT_ID}"
+      - "AAD_TENANT_ID=${AAD_TENANT_ID}"
+      - "AAD_CLIENT_SECRET=${AAD_CLIENT_SECRET}"
+      - "AAD_REDIRECT_URI=${AAD_REDIRECT_URI}"
+      - "AAD_PROVIDER=${AAD_PROVIDER}"
+      - "AAD_PROVIDER_USER=${AAD_PROVIDER_USER}"
+      - "AAD_MISP_USER=${AAD_MISP_USER}"
+      - "AAD_MISP_ORGADMIN=${AAD_MISP_ORGADMIN}"
+      - "AAD_MISP_SITEADMIN=${AAD_MISP_SITEADMIN}"
+      - "AAD_CHECK_GROUPS=${AAD_CHECK_GROUPS}"
       # sync server settings (see https://www.misp-project.org/openapi/#tag/Servers for more options)
       - "SYNCSERVERS=${SYNCSERVERS}"
       - |

--- a/template.env
+++ b/template.env
@@ -119,3 +119,15 @@ SYNCSERVERS_1_KEY=
 # LDAP_OPT_PROTOCOL_VERSION="3"
 # LDAP_OPT_NETWORK_TIMEOUT="-1"
 # LDAP_OPT_REFERRALS=false
+
+# Enable Azure AD (Entra) authentication, according to https://github.com/MISP/MISP/blob/2.4/app/Plugin/AadAuth/README.md
+# AAD_CLIENT_ID=
+# AAD_TENANT_ID=
+# AAD_CLIENT_SECRET=
+# AAD_REDIRECT_URI="https://misp.mydomain.com/users/login"
+# AAD_PROVIDER="https://login.microsoftonline.com/"
+# AAD_PROVIDER_USER="https://graph.microsoft.com/"
+# AAD_MISP_USER="Misp Users"
+# AAD_MISP_ORGADMIN="Misp Org Admins"
+# AAD_MISP_SITEADMIN="Misp Site Admins"
+# AAD_CHECK_GROUPS=false


### PR DESCRIPTION
Add support for enabling Azure AD (aka Entra) authentication via the configure_misp.sh script. The function to enable Azure AD auth mirrors the code in the existing functions to enable OIDC and LDAP auth.

Environment variables are provided to configure available options in the AadAuth plugin: https://github.com/MISP/MISP/tree/2.4/app/Plugin/AadAuth

This commit addresses issue "AAD Auth not working" #34. https://github.com/MISP/misp-docker/issues/34