### PR TITLE
Fix #40 Add exemption to entrypoint_nginx for taxonomies

### DIFF
--- a/core/files/entrypoint_nginx.sh
+++ b/core/files/entrypoint_nginx.sh
@@ -148,7 +148,7 @@ EOT
 
 update_misp_data_files(){
     for DIR in $(ls /var/www/MISP/app/files.dist); do
-        if [ "$DIR" = "certs" ] || [ "$DIR" = "img" ] ; then
+        if [ "$DIR" = "certs" ] || [ "$DIR" = "img" ] || [ "$DIR" == "taxonomies" ] ; then
             echo "... rsync -azh \"/var/www/MISP/app/files.dist/$DIR\" \"/var/www/MISP/app/files/\""
             rsync -azh "/var/www/MISP/app/files.dist/$DIR" "/var/www/MISP/app/files/"
         else


### PR DESCRIPTION
### What does it do?
The change fixes https://github.com/MISP/misp-docker/issues/40

### Expected behavior
The taxonomies should be persistent after restarting or updating the core container