### PR TITLE
Fix missing AadAuth env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,7 @@ services:
       - "LDAP_OPT_NETWORK_TIMEOUT=${LDAP_OPT_NETWORK_TIMEOUT}"
       - "LDAP_OPT_REFERRALS=${LDAP_OPT_REFERRALS}"
       # AAD authentication settings
+      - "AAD_ENABLE=${AAD_ENABLE}"
       - "AAD_CLIENT_ID=${AAD_CLIENT_ID}"
       - "AAD_TENANT_ID=${AAD_TENANT_ID}"
       - "AAD_CLIENT_SECRET=${AAD_CLIENT_SECRET}"

--- a/template.env
+++ b/template.env
@@ -121,6 +121,7 @@ SYNCSERVERS_1_KEY=
 # LDAP_OPT_REFERRALS=false
 
 # Enable Azure AD (Entra) authentication, according to https://github.com/MISP/MISP/blob/2.4/app/Plugin/AadAuth/README.md
+# AAD_ENABLE=true
 # AAD_CLIENT_ID=
 # AAD_TENANT_ID=
 # AAD_CLIENT_SECRET=


### PR DESCRIPTION
Pull request #39 added support for Entra/AzureAD authentication (AadAuth). However, the request accidentally omitted the `AAD_ENABLE` environment variable from `template.env` and `docker-compose.yml`. This pull request fixes that omission.