### PR TITLE
Allow Redis over TLS

### DIFF
--- a/core/files/entrypoint_fpm.sh
+++ b/core/files/entrypoint_fpm.sh
@@ -19,7 +19,7 @@ change_php_vars() {
         sed -i "s/upload_max_filesize = .*/upload_max_filesize = 50M/" "$FILE"
         sed -i "s/post_max_size = .*/post_max_size = 50M/" "$FILE"
         sed -i "s/session.save_handler = .*/session.save_handler = redis/" "$FILE"
-        sed -i "s|.*session.save_path = .*|session.save_path = 'tcp://${REDIS_FQDN}:6379'|" "$FILE"
+        sed -i "s|.*session.save_path =.*|session.save_path = '$(echo $REDIS_FQDN | grep -E '^\w+://' || echo tcp://$REDIS_FQDN):6379'|" "$FILE"
     done
 }
 

--- a/core/files/entrypoint_fpm.sh
+++ b/core/files/entrypoint_fpm.sh
@@ -19,7 +19,7 @@ change_php_vars() {
         sed -i "s/upload_max_filesize = .*/upload_max_filesize = 50M/" "$FILE"
         sed -i "s/post_max_size = .*/post_max_size = 50M/" "$FILE"
         sed -i "s/session.save_handler = .*/session.save_handler = redis/" "$FILE"
-        sed -i "s|.*session.save_path =.*|session.save_path = '$(echo $REDIS_FQDN | grep -E '^\w+://' || echo tcp://$REDIS_FQDN):6379'|" "$FILE"
+        sed -i "s|.*session.save_path = .*|session.save_path = '$(echo $REDIS_FQDN | grep -E '^\w+://' || echo tcp://$REDIS_FQDN):6379'|" "$FILE"
     done
 }
 


### PR DESCRIPTION
### What does it do?
It fixes #47 by prepending `tcp://` only when not present in `$REDIS_FQDN` already.