### PR TITLE
Support optional OIDC_ISSUER parameter

### DIFF
--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -103,6 +103,7 @@ set_up_oidc() {
     fi
 
     # Check required variables
+    # OIDC_ISSUER may be empty
     check_env_vars OIDC_PROVIDER_URL OIDC_CLIENT_ID OIDC_CLIENT_SECRET OIDC_ROLES_PROPERTY OIDC_ROLES_MAPPING OIDC_DEFAULT_ORG
 
     sudo -u www-data php /var/www/MISP/tests/modify_config.php modify "{
@@ -114,6 +115,7 @@ set_up_oidc() {
     sudo -u www-data php /var/www/MISP/tests/modify_config.php modify "{
         \"OidcAuth\": {
             \"provider_url\": \"${OIDC_PROVIDER_URL}\",
+            ${OIDC_ISSUER:+\"issuer\": \"${OIDC_ISSUER}\",}
             \"client_id\": \"${OIDC_CLIENT_ID}\",
             \"client_secret\": \"${OIDC_CLIENT_SECRET}\",
             \"roles_property\": \"${OIDC_ROLES_PROPERTY}\",


### PR DESCRIPTION
Following https://github.com/MISP/MISP/pull/9694 merge, supporting new optional OIDC parameter.

From shell docs:
`${parameter:+word}`
`If parameter is null or unset, nothing is substituted, otherwise the expansion of word is substituted.`

I used this method since issuer should be null and not an empty string in case it's missing (Unsure about whether MISP understands an empty string as null value).