### PR TITLE
Fix issue where searching for '.php' returns an error

### DIFF
--- a/core/files/etc/nginx/includes/misp
+++ b/core/files/etc/nginx/includes/misp
@@ -21,8 +21,11 @@ location / {
     try_files $uri $uri/ /index.php$is_args$query_string;
 }
 
-location ~ \.php$ {
+location ~ ^/[^/]+\.php(/|$) {
     include snippets/fastcgi-php.conf;
     fastcgi_pass unix:/var/run/php/php7.4-fpm.sock;
     fastcgi_read_timeout 300;
+    fastcgi_split_path_info ^(.+\.php)(/.+)$;
+    set $path_info $fastcgi_path_info;
+    fastcgi_param PATH_INFO $path_info;
 }


### PR DESCRIPTION
If you search MISP for something ending in .php, the nginx location directive is too broad, and will match.  This results in nginx attempting to load the search path as a file.

Consider:
- Search for `something.php`
- The URL accessed becomes `/events/index/searcheventinfo:something.php`
- The MISP nginx location directive this passes through is predicated on the path`\.php$`

This will obviously match, and nginx attempt to load `searcheventinfo:something.php`, and this is what we see:

![image](https://github.com/MISP/misp-docker/assets/85923673/7f8e7e5a-9058-4fb1-b886-0d7db5c71a1e)

This commit causes the file path (`$fastcgi_script_name`) and subsequent path (`$fastcgi_path_info`) to be passed as separate parameters to fastcgi, so that any arbitrary path ending in .php is not interpreted as a script name.

I've been running this fix for months on my own misp-docker instances, and haven't had any issues.