### PR TITLE
Fix issue with Misp modules

### DIFF
--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -211,6 +211,11 @@ set_up_aad() {
     sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q "Security.require_password_confirmation" false
 }
 
+fix_modules_controller() {
+    # Remove errored lines in modules controller
+    sed -i '25,27d' /var/www/MISP/app/Controller/ModulesController.php
+}
+
 apply_updates() {
     # Disable weird default
     sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q "Plugin.ZeroMQ_enable" false
@@ -378,6 +383,8 @@ echo "MISP | Set Up OIDC ..." && set_up_oidc
 echo "MISP | Set Up LDAP ..." && set_up_ldap
 
 echo "MISP | Set Up AAD ..." && set_up_aad
+
+echo "INIT MISP | Fix ModulesController.php ..." && fix_modules_controller
 
 echo "MISP | Mark instance live"
 sudo -u www-data /var/www/MISP/app/Console/cake Admin live 1


### PR DESCRIPTION
Fix issue with Misp modules (ModulesController.php file)

We had an error when using MISP modules (modules/queryEnrichment API endpoint)
After full investigation, this fixed our error.
I think it's very important to add it, since we would like to use the updated official version of MISP.

This is the full error, take from `error.log`:
```
Error: [TypeError] Argument 3 passed to Module::canUse() must be of the type array, string given, called in /var/www/MISP/app/Controller/ModulesController.php on line 25
Request URL: /modules/queryEnrichment
Stack Trace:
#0 /var/www/MISP/app/Controller/ModulesController.php(25): Module->canUse()
#1 [internal function]: ModulesController->queryEnrichment()
#2 /var/www/MISP/app/Lib/cakephp/lib/Cake/Controller/Controller.php(499): ReflectionMethod->invokeArgs()
#3 /var/www/MISP/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(193): Controller->invokeAction()
#4 /var/www/MISP/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(167): Dispatcher->_invoke()
#5 /var/www/MISP/app/webroot/index.php(101): Dispatcher->dispatch()
#6 {main}
```

After removing lines 25-27 on `/var/www/MISP/app/Controller/ModulesController.php` the issue was solved and we got MISP modules working again.

Thanks!