### PR TITLE
Add option to configure proxy using environment vars

### DIFF
--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -211,6 +211,21 @@ set_up_aad() {
     sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q "Security.require_password_confirmation" false
 }
 
+set_up_proxy() {
+    if [[ "$PROXY_ENABLE" != "true" ]]; then
+        echo "... Proxy disabled"
+        return
+    fi
+
+    echo "... configuring proxy settings"
+
+    sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q "Proxy.host" "$PROXY_HOST"
+    sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q "Proxy.port" "$PROXY_PORT"
+    sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q "Proxy.method" "$PROXY_METHOD"
+    sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q "Proxy.user" "$PROXY_USER"
+    sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q "Proxy.password" "$PROXY_PASSWORD"
+}
+
 apply_updates() {
     # Disable weird default
     sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q "Plugin.ZeroMQ_enable" false
@@ -378,6 +393,8 @@ echo "MISP | Set Up OIDC ..." && set_up_oidc
 echo "MISP | Set Up LDAP ..." && set_up_ldap
 
 echo "MISP | Set Up AAD ..." && set_up_aad
+
+echo "MISP | Set Up Proxy ..." && set_up_proxy
 
 echo "MISP | Mark instance live"
 sudo -u www-data /var/www/MISP/app/Console/cake Admin live 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,6 +129,12 @@ services:
       - "AAD_MISP_ORGADMIN=${AAD_MISP_ORGADMIN}"
       - "AAD_MISP_SITEADMIN=${AAD_MISP_SITEADMIN}"
       - "AAD_CHECK_GROUPS=${AAD_CHECK_GROUPS}"
+      # Proxy settings
+      - "PROXY_HOST=${PROXY_HOST}"
+      - "PROXY_PORT=${PROXY_PORT}"
+      - "PROXY_METHOD=${PROXY_METHOD}"
+      - "PROXY_USER=${PROXY_USER}"
+      - "PROXY_PASSWORD=${PROXY_PASSWORD}"
       # sync server settings (see https://www.misp-project.org/openapi/#tag/Servers for more options)
       - "SYNCSERVERS=${SYNCSERVERS}"
       - |

--- a/template.env
+++ b/template.env
@@ -132,3 +132,11 @@ SYNCSERVERS_1_KEY=
 # AAD_MISP_ORGADMIN="Misp Org Admins"
 # AAD_MISP_SITEADMIN="Misp Site Admins"
 # AAD_CHECK_GROUPS=false
+
+# Enable the use of a Proxy server
+# PROXY_ENABLE=true
+# PROXY_HOST=
+# PROXY_PORT=
+# PROXY_METHOD=
+# PROXY_USER=
+# PROXY_PASSWORD=


### PR DESCRIPTION
There is currently no option in the configuration script to set the values for the proxy settings. This is cumbersome to change each time a new pod is deployed on our k8s cluster. This change makes it possible to use environment variables to solve this issue.