### PR TITLE
Core - Enhanced the validity check of Nginx's dhparam.pem file during configuration phase

### DIFF
--- a/core/files/entrypoint_nginx.sh
+++ b/core/files/entrypoint_nginx.sh
@@ -255,7 +255,7 @@ init_nginx() {
         echo "... TLS certificates found"
     fi
     
-    if [[ ! -f /etc/nginx/certs/dhparams.pem ]]; then
+    if [[ ! -f /etc/nginx/certs/dhparams.pem ]] || ! openssl dhparam -in /etc/nginx/certs/dhparam.pem -noout -check; then
         echo "... generating new DH parameters"
         openssl dhparam -out /etc/nginx/certs/dhparams.pem 2048
     else


### PR DESCRIPTION
Whenever I tried running the misp-core image, it'd get stuck on an infinite loop of Nginx trying to start up, then failing due to invalid DHParam.pem file.

For unknown reasons, the file existed, but was empty every time.

This PR fixes that by enhancing the dhparam.pem file check, adding a contents check of the file, and if anything other than a valid DH Params are found, regenerates the file.