### PR TITLE
Fix unintentional dependence upon health check to trigger runUpdates, and password length issue

### DIFF
--- a/core/files/etc/misp-docker/initialisation.defaults.json
+++ b/core/files/etc/misp-docker/initialisation.defaults.json
@@ -2,15 +2,6 @@
   "MISP.ca_path": {
     "default_value": "/var/www/MISP/app/Lib/cakephp/lib/Cake/Config/cacert.pem"
   },
-  "MISP.redis_port": {
-    "default_value": 6379
-  },
-  "MISP.redis_database": {
-    "default_value": 13
-  },
-  "MISP.redis_password": {
-    "default_value": ""
-  },
   "MISP.language": {
     "default_value": "eng"
   },
@@ -112,6 +103,10 @@
   },
   "Security.check_sec_fetch_site_header": {
     "default_value": true
+  },
+  "Security.encryption_key": {
+    "default_value": "",
+    "command_args": "-f"
   },
   "Security.username_in_response_header": {
     "default_value": true

--- a/core/files/etc/misp-docker/initialisation.envars.json
+++ b/core/files/etc/misp-docker/initialisation.envars.json
@@ -12,9 +12,6 @@
   "MISP.contact": {
     "default_value": "${SETTING_CONTACT}"
   },
-  "MISP.redis_host": {
-    "default_value": "${REDIS_FQDN}"
-  },
   "Plugin.ZeroMQ_redis_host": {
     "default_value": "${REDIS_FQDN}"
   },

--- a/core/files/etc/misp-docker/minimum_config.defaults.json
+++ b/core/files/etc/misp-docker/minimum_config.defaults.json
@@ -24,6 +24,15 @@
     "default_value": "/etc/ssl/certs/ca-certificates.crt",
     "command_args": "-f"
   },
+  "MISP.redis_port": {
+    "default_value": 6379
+  },
+  "MISP.redis_database": {
+    "default_value": 13
+  },
+  "MISP.redis_password": {
+    "default_value": ""
+  },
   "MISP.menu_custom_right_link": {
     "default_value": ""
   },

--- a/core/files/etc/misp-docker/minimum_config.envars.json
+++ b/core/files/etc/misp-docker/minimum_config.envars.json
@@ -2,6 +2,9 @@
   "MISP.python_bin": {
     "default_value": "${PYTHON_BIN}"
   },
+  "MISP.redis_host": {
+    "default_value": "${REDIS_FQDN}"
+  },
   "GnuPG.binary": {
     "default_value": "${GPG_BINARY}"
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,7 @@ services:
       timeout: 1s
       retries: 3
       start_period: 30s
+      start_interval: 30s
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
Remove await_system_settings_table() entirely
Move redis specific config items to minimum_config*json
Adjust where runUpdates is called

- Fixes #73 

Fix password length setting issue caused by jq quoting

- Fixes #74 

Silence error caused cake admin init user

Linebuffer some outputs so they look nicer

Add start_interval to docker-compose.yml to avoid runUpdates race condition caused by health check which could lead to bad db updates, which seems to have been an issue for quite a while but is very hard to reproduce.  issue stems from healthcheck runUpdate being clobbered by configure_misp runUpdate as runUpdate's locking mechanism is not respected by the next run.  by setting the start interval to be the same as the start period, we seem to make it significantly less likely that there will be a clobbering.  seems to give about 15 seconds leeway.  the ideal solution would be to have a configurable option to toggle whether runupdates occurs from browser visits, but this fix has made the issue dramatically less likely.

example of this issue from an image built from 887d1b344326187dcd7272a0e0edc5863c1edd4f (prior to my changes):

```
...
misp-core-1  | 2024-06-13T05:43:53.799745573Z gpg: Done
misp-core-1  | 2024-06-13T05:43:53.810864686Z ... exporting GPG key
misp-core-1  | 2024-06-13T05:43:54.163286570Z MISP | Apply updates ...
misp-core-1  | 2024-06-13T05:43:58.433320675Z Error: SQLSTATE[42000]: Syntax error or access violation: 1061 Duplicate key name 'unique_correlation'
misp-core-1  | 2024-06-13T05:43:58.433338485Z #0 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Datasource/DboSource.php(502): PDOStatement->execute()
misp-core-1  | 2024-06-13T05:43:58.433343234Z #1 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Datasource/DboSource.php(468): DboSource->_execute()
misp-core-1  | 2024-06-13T05:43:58.433346796Z #2 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Datasource/DboSource.php(715): DboSource->execute()
misp-core-1  | 2024-06-13T05:43:58.433351545Z #3 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Datasource/DboSource.php(641): DboSource->fetchAll()
misp-core-1  | 2024-06-13T05:43:58.433356295Z #4 /var/www/MISP/app/Lib/cakephp/lib/Cake/Model/Model.php(3489): DboSource->query()
misp-core-1  | 2024-06-13T05:43:58.433359856Z #5 /var/www/MISP/app/Model/AppModel.php(258): Model->query()
misp-core-1  | 2024-06-13T05:43:58.433364606Z #6 /var/www/MISP/app/Model/AppModel.php(2740): AppModel->updateMISP()
misp-core-1  | 2024-06-13T05:43:58.433369355Z #7 /var/www/MISP/app/Console/Command/AdminShell.php(591): AppModel->runUpdates()
misp-core-1  | 2024-06-13T05:43:58.433374104Z #8 /var/www/MISP/app/Lib/cakephp/lib/Cake/Console/Shell.php(459): AdminShell->runUpdates()
misp-core-1  | 2024-06-13T05:43:58.433380041Z #9 /var/www/MISP/app/Lib/cakephp/lib/Cake/Console/ShellDispatcher.php(222): Shell->runCommand()
misp-core-1  | 2024-06-13T05:43:58.433383603Z #10 /var/www/MISP/app/Lib/cakephp/lib/Cake/Console/ShellDispatcher.php(66): ShellDispatcher->dispatch()
misp-core-1  | 2024-06-13T05:43:58.433388352Z #11 /var/www/MISP/app/Console/cake.php(45): ShellDispatcher::run()
misp-core-1  | 2024-06-13T05:43:58.433393101Z #12 {main}
misp-core-1  | 2024-06-13T05:43:58.438770406Z Executing all updates to bring the database up to date with the current version.
misp-core-1  | 2024-06-13T05:43:58.438783467Z Executing 71..................Done
misp-core-1  | 2024-06-13T05:43:58.438788216Z Executing 72..................Done
misp-core-1  | 2024-06-13T05:43:58.438791778Z Executing 73..................Done
misp-core-1  | 2024-06-13T05:43:58.438795340Z Executing 74..................Done
misp-core-1  | 2024-06-13T05:43:58.438798902Z Executing 75..................Done
misp-core-1  | 2024-06-13T05:43:58.438802464Z Executing 76..................Done
misp-core-1  | 2024-06-13T05:43:58.438807213Z Executing 77..................Done
misp-core-1  | 2024-06-13T05:43:58.438810775Z Executing 78..................Done
misp-core-1  | 2024-06-13T05:43:58.438814337Z Executing 79..................Done
misp-core-1  | 2024-06-13T05:43:58.438819086Z Executing 80..................Done
misp-core-1  | 2024-06-13T05:43:58.438822648Z Executing 81..................Done
misp-core-1  | 2024-06-13T05:43:58.438833334Z Executing 82..................Done
misp-core-1  | 2024-06-13T05:43:58.438838083Z Executing 83..................Done
misp-core-1  | 2024-06-13T05:43:58.438842832Z Executing 84..................Done
misp-core-1  | 2024-06-13T05:43:58.438847581Z Executing 85..................Done
misp-core-1  | 2024-06-13T05:43:58.438852331Z Executing 86..................Done
misp-core-1  | 2024-06-13T05:43:58.438855892Z Executing 87..................Done
misp-core-1  | 2024-06-13T05:43:58.438860642Z Executing 88..................Done
misp-core-1  | 2024-06-13T05:43:58.438865391Z Executing 89..................Done
misp-core-1  | 2024-06-13T05:43:58.438868953Z Executing 90..................Done
misp-core-1  | 2024-06-13T05:43:58.439035176Z Executing 91..................MISP | Init default user and organization ...
misp-core-1  | 2024-06-13T05:43:58.504056760Z Warning: This method is deprecated. Next time please use `cake user init`.
misp-core-1  | 2024-06-13T05:43:58.533302463Z ... admin user key auto generation disabled
misp-core-1  | 2024-06-13T05:43:58.533321460Z ... setting admin password skipped
...
```

as you can see, it starts at 71, when it should be 65.  also ends at 91 when it should end at 125.  looks like a 2 way clobbering:

1. healthcheck causes runupdates
2. configure_misp causes runupdate, clobbering 1
3. healtcheck causes runupdate, clobbering 2

this CAN lead to failed updates, which are progressed past on the next run.  the db version will then show as latest, but actually be missing one or more updates.  causing this to happen is very hard, but i have seen it a few times.