### PR TITLE
Make SMTP host setting configurable

### DIFF
--- a/core/files/entrypoint_nginx.sh
+++ b/core/files/entrypoint_nginx.sh
@@ -18,6 +18,7 @@ trap term_proc SIGTERM
 [ -z "$BASE_URL" ] && export BASE_URL="https://localhost"
 [ -z "$DISABLE_IPV6" ] && export DISABLE_IPV6=false
 [ -z "$DISABLE_SSL_REDIRECT" ] && export DISABLE_SSL_REDIRECT=false
+[ -z "$SMTP_FQDN" ] && export SMTP_FQDN=mail
 
 init_mysql(){
     # Test when MySQL is ready....
@@ -93,7 +94,7 @@ class EmailConfig {
     public \$default = array(
         'transport'     => 'Smtp',
         'from'          => array('misp-dev@admin.test' => 'Misp DEV'),
-        'host'          => 'mail',
+        'host'          => '$SMTP_FQDN',
         'port'          => 25,
         'timeout'       => 30,
         'client'        => null,
@@ -102,7 +103,7 @@ class EmailConfig {
     public \$smtp = array(
         'transport'     => 'Smtp',
         'from'          => array('misp-dev@admin.test' => 'Misp DEV'),
-        'host'          => 'mail',
+        'host'          => '$SMTP_FQDN',
         'port'          => 25,
         'timeout'       => 30,
         'client'        => null,
@@ -128,7 +129,7 @@ class EmailConfig {
         'attachments'   => null,
         'emailFormat'   => null,
         'transport'     => 'Smtp',
-        'host'          => 'mail',
+        'host'          => '$SMTP_FQDN',
         'port'          => 25,
         'timeout'       => 30,
         'client'        => null,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,7 +159,7 @@ services:
       # Debug setting 
       - "DEBUG=${DEBUG}"
       # SMTP setting
-      - "SMTP_FQDN=${SMTP_FQDN:-mail}"
+      - "SMTP_FQDN=${SMTP_FQDN}"
   
   misp-modules:
     image: ghcr.io/misp/misp-docker/misp-modules:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,6 +158,8 @@ services:
       - "MYSQL_DATABASE=${MYSQL_DATABASE:-misp}"
       # Debug setting 
       - "DEBUG=${DEBUG}"
+      # SMTP setting
+      - "SMTP_FQDN=${SMTP_FQDN:-mail}"
   
   misp-modules:
     image: ghcr.io/misp/misp-docker/misp-modules:latest

--- a/template.env
+++ b/template.env
@@ -44,6 +44,9 @@ BASE_URL=
 # store settings in db except those that must stay in config.php. true/false, defaults to false
 ENABLE_DB_SETTINGS=
 
+# Defines what mail system to use defaults to 'mail' which is provided in docker-compose.yml
+SMTP_FQDN=mail
+
 # optional and used by the mail sub-system
 SMARTHOST_ADDRESS=
 SMARTHOST_PORT=

--- a/template.env
+++ b/template.env
@@ -45,7 +45,7 @@ BASE_URL=
 ENABLE_DB_SETTINGS=
 
 # Defines what mail system to use defaults to 'mail' which is provided in docker-compose.yml
-SMTP_FQDN=mail
+# SMTP_FQDN=mail
 
 # optional and used by the mail sub-system
 SMARTHOST_ADDRESS=

--- a/template.env
+++ b/template.env
@@ -45,7 +45,7 @@ BASE_URL=
 ENABLE_DB_SETTINGS=
 
 # Defines what mail system to use defaults to 'mail' which is provided in docker-compose.yml
-# SMTP_FQDN=mail
+SMTP_FQDN=mail
 
 # optional and used by the mail sub-system
 SMARTHOST_ADDRESS=


### PR DESCRIPTION
Allows to configure a SMTP server different from the one in docker-compose while making the docker-compose one the default.