### PR TITLE
Added note for escaping LDAP password in template.env

### DIFF
--- a/template.env
+++ b/template.env
@@ -113,7 +113,7 @@ SYNCSERVERS_1_KEY=
 # LDAP_SERVER="ldap://your_domain_controller"
 # LDAP_STARTTLS=true
 # LDAP_READER_USER="CN=service_account_name,OU=Users,DC=domain,DC=net"
-# LDAP_READER_PASSWORD="password"
+# LDAP_READER_PASSWORD="password" # Doubly escape necessary special characters inside the password. E.g. literal "pass\word" should be escaped as "pass\\\\word"
 # LDAP_DN="OU=Users,DC=domain,DC=net"
 # LDAP_SEARCH_FILTER=""
 # LDAP_SEARCH_ATTRIBUTE="uid"


### PR DESCRIPTION
If the LDAP password contains special characters that need escaping, they must be doubly escaped inside .env.

Added a reminder against the password field for that.