### PR TITLE
set php parameters sid_length and use_strict_mode

### DIFF
--- a/core/files/entrypoint_fpm.sh
+++ b/core/files/entrypoint_fpm.sh
@@ -20,6 +20,8 @@ change_php_vars() {
         sed -i "s/post_max_size = .*/post_max_size = 50M/" "$FILE"
         sed -i "s/session.save_handler = .*/session.save_handler = redis/" "$FILE"
         sed -i "s|.*session.save_path = .*|session.save_path = '$(echo $REDIS_FQDN | grep -E '^\w+://' || echo tcp://$REDIS_FQDN):6379'|" "$FILE"
+        sed -i "s/session.sid_length = .*/session.sid_length = 64/" "$FILE"
+        sed -i "s/session.use_strict_mode = .*/session.use_strict_mode = 1/" "$FILE"
     done
 }
 


### PR DESCRIPTION
these shall be set to 
sid_length > 32
use_strict_mode = 1

Otherwise even MISP will complain about this in Diagnostics