### PR TITLE
Balance quotes as required by podman 4.9.4

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -156,7 +156,7 @@ EOF
         find /var/www/MISP/INSTALL/* ! -name 'MYSQL.sql' -type l -exec rm {} +
         # Remove most files in .git - we do not use git functionality in docker
         find /var/www/MISP/.git/* ! -name HEAD -exec rm -rf {} +
-        # Remove libraries' submodules
+        # Remove libraries submodules
         rm -r /var/www/MISP/PyMISP
         rm -r /var/www/MISP/app/files/scripts/cti-python-stix2
         rm -r /var/www/MISP/app/files/scripts/misp-stix


### PR DESCRIPTION
Podman 4.9.4 requires all quotes to be balanced when processing heredoc RUN statements, including in comments. Without the change building the container yields the following ERROR: "unexpected end of statement while looking for matching single-quote". The proposed change allows misp-core to be built using podman-compose on redhat 9.4. 