### PR TITLE
Enable auditlog for misp-core & honouring image TAG variables for podman-compose pull 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
 
   misp-core:
     image: ghcr.io/misp/misp-docker/misp-core:latest
+    cap_add:
+      - CAP_AUDIT_WRITE
     build:
       context: core/.
       args:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       start_period: 30s
 
   misp-core:
-    image: ghcr.io/misp/misp-docker/misp-core:latest
+    image: ghcr.io/misp/misp-docker/misp-core:${CORE_TAG}
     cap_add:
       - CAP_AUDIT_WRITE
     build:
@@ -169,7 +169,7 @@ services:
       - "SMTP_FQDN=${SMTP_FQDN}"
   
   misp-modules:
-    image: ghcr.io/misp/misp-docker/misp-modules:latest
+    image: ghcr.io/misp/misp-docker/misp-modules:${MODULES_TAG}
     build:
       context: modules/.
       args:


### PR DESCRIPTION
Hi
when using podman-compose up, it spamms the logs with:
[misp-core]    | sudo: unable to send audit message: Operation not permitted
This is due insufficient capabilities in podman, please add this line to allow audit log writes.
This can only write audit logs, and not configure/delete them...