### PR TITLE
Allow Auditlog writes and get rid of message: "sudo: unable to send a…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
 
   misp-core:
     image: ghcr.io/misp/misp-docker/misp-core:latest
+    cap_add:
+      - CAP_AUDIT_WRITE
     build:
       context: core/.
       args:


### PR DESCRIPTION
Hi
when using podman-compose up, it spamms the logs with:
[misp-core] | sudo: unable to send audit message: Operation not permitted
This is due insufficient capabilities in podman, please add this line to allow audit log writes.
This can only write audit logs, and not configure/delete them...

I do not use docker and docker-compose, but i installed docker-ce and removed podman, its running as expected.
```
[root@test-misp ~]# docker inspect misp-containers-misp-core-1 | jq '.[0].HostConfig | {CapAdd, CapDrop}'
{
  "CapAdd": [
    "CAP_AUDIT_WRITE"
  ],
  "CapDrop": null
}




root@test-misp ~]# docker ps
CONTAINER ID   IMAGE                                            COMMAND                  CREATED         STATUS                   PORTS                                                                      NAMES
1fe9de39c94c   ghcr.io/misp/misp-docker/misp-core:v2.4.195      "/entrypoint.sh"         6 minutes ago   Up 6 minutes (healthy)   0.0.0.0:80->80/tcp, :::80->80/tcp, 0.0.0.0:443->443/tcp, :::443->443/tcp   misp-containers-misp-core-1
48695cfde346   ghcr.io/misp/misp-docker/misp-modules:v2.4.195   "/usr/local/bin/misp…"   6 minutes ago   Up 6 minutes                                                                                        misp-containers-misp-modules-1
eab18db7dbde   mariadb:10.11                                    "docker-entrypoint.s…"   6 minutes ago   Up 6 minutes (healthy)   3306/tcp                                                                   misp-containers-db-1
945497e9b0b7   valkey/valkey:7.2                                "docker-entrypoint.s…"   6 minutes ago   Up 6 minutes (healthy)   6379/tcp                                                                   misp-containers-redis-1
cb93eb98ff1d   ixdotai/smtp                                     "/bin/entrypoint.sh …"   6 minutes ago   Up 6 minutes             25/tcp                                                                     misp-containers-mail-1
[root@test-misp ~]# docker images
REPOSITORY                              TAG        IMAGE ID       CREATED        SIZE
ghcr.io/misp/misp-docker/misp-core      v2.4.195   f0116819b96b   45 hours ago   1.1GB
ghcr.io/misp/misp-docker/misp-modules   v2.4.195   be5fee136e5d   45 hours ago   1.16GB
mariadb                                 10.11      87ebf6d8f272   6 days ago     405MB
valkey/valkey                           7.2        84caf4805760   13 days ago    134MB
ixdotai/smtp                            latest     b9c77252424a   4 weeks ago    93.5MB
[root@test-misp ~]# docker version
Client: Docker Engine - Community
 Version:           27.1.2
 API version:       1.46
 Go version:        go1.21.13
 Git commit:        d01f264
 Built:             Mon Aug 12 11:52:33 2024
 OS/Arch:           linux/amd64
 Context:           default

Server: Docker Engine - Community
 Engine:
  Version:          27.1.2
  API version:      1.46 (minimum version 1.24)
  Go version:       go1.21.13
  Git commit:       f9522e5
  Built:            Mon Aug 12 11:50:54 2024
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.7.20
  GitCommit:        8fc6bcff51318944179630522a095cc9dbf9f353
 runc:
  Version:          1.1.13
  GitCommit:        v1.1.13-0-g58aa920
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0

```

