### PR TITLE
added `*_TAG` vars instead of latest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       start_period: 30s
 
   misp-core:
-    image: ghcr.io/misp/misp-docker/misp-core:latest
+    image: ghcr.io/misp/misp-docker/misp-core:${CORE_TAG}
     build:
       context: core/.
       args:
@@ -167,7 +167,7 @@ services:
       - "SMTP_FQDN=${SMTP_FQDN}"
   
   misp-modules:
-    image: ghcr.io/misp/misp-docker/misp-modules:latest
+    image: ghcr.io/misp/misp-docker/misp-modules:${MODULES_TAG}
     build:
       context: modules/.
       args:


### PR DESCRIPTION
One more pull request.
latest tags in docker-compose.yml lead into different results between build and pull:

    build is honouring *_TAG
    pull is always getting latest tag.
    this is not reflecting ability to use docker image tags, but since .env can not reflect this logic, this is most you can do.
    thanks Chris
