### PR TITLE
Extend customization of redis variables and unify defaults

### DIFF
--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -2,19 +2,8 @@
 
 source /rest_client.sh
 source /utilities.sh
-[ -z "$ADMIN_EMAIL" ] && export ADMIN_EMAIL="admin@admin.test"
-[ -z "$GPG_PASSPHRASE" ] && export GPG_PASSPHRASE="passphrase"
-[ -z "$REDIS_FQDN" ] && export REDIS_FQDN="redis"
-[ -z "$MISP_MODULES_FQDN" ] && export MISP_MODULES_FQDN="http://misp-modules"
 
-# Switches to selectively disable configuration logic
-[ -z "$AUTOCONF_GPG" ] && AUTOCONF_GPG="true"
-[ -z "$AUTOCONF_ADMIN_KEY" ] && AUTOCONF_ADMIN_KEY="true"
-[ -z "$OIDC_ENABLE" ] && OIDC_ENABLE="false"
-[ -z "$LDAP_ENABLE" ] && LDAP_ENABLE="false"
-[ -z "$ENABLE_DB_SETTINGS" ] && ENABLE_DB_SETTINGS="false"
-[ -z "$PROXY_ENABLE" ] && PROXY_ENABLE="false"
-[ -z "$DEBUG" ] && DEBUG=0
+MYSQLCMD="mysql -u $MYSQL_USER -p$MYSQL_PASSWORD -P $MYSQL_PORT -h $MYSQL_HOST -r -N $MYSQL_DATABASE"
 
 # We now use envsubst for safe variable substitution with pseudo-json objects for env var enforcement
 # envsubst won't evaluate anything like $() or conditional variable expansion so lets do that here

--- a/core/files/entrypoint.sh
+++ b/core/files/entrypoint.sh
@@ -7,5 +7,31 @@ export NUM_WORKERS_EMAIL=${NUM_WORKERS_EMAIL:-${WORKERS:-5}}
 export NUM_WORKERS_UPDATE=${NUM_WORKERS_UPDATE:-${WORKERS:-1}}
 export NUM_WORKERS_CACHE=${NUM_WORKERS_CACHE:-${WORKERS:-5}}
 
+export MYSQL_HOST=${MYSQL_HOST:-db}
+export MYSQL_PORT=${MYSQL_PORT:-3306}
+export MYSQL_USER=${MYSQL_USER:-misp}
+export MYSQL_PASSWORD=${MYSQL_PASSWORD:-example}
+export MYSQL_DATABASE=${MYSQL_DATABASE:-misp}
+export REDIS_HOST=${REDIS_HOST:-redis}
+export REDIS_PORT=${REDIS_PORT:-6379}
+export REDIS_PASSWORD=${REDIS_PASSWORD:-redispassword}
+export CRON_USER_ID=${CRON_USER_ID:-1}
+export BASE_URL=${BASE_URL:-https://localhost}
+export DISABLE_IPV6=${DISABLE_IPV6:-false}
+export DISABLE_SSL_REDIRECT=${DISABLE_SSL_REDIRECT:-false}
+export SMTP_FQDN=${SMTP_FQDN:-mail}
+
+export ADMIN_EMAIL=${ADMIN_EMAIL:-admin@admin.test}
+export GPG_PASSPHRASE=${GPG_PASSPHRASE:-passphrase}
+export MISP_MODULES_FQDN=${MISP_MODULES_FQDN:-http://misp-modules}
+
+export AUTOCONF_GPG=${AUTOCONF_GPG:-true}
+export AUTOCONF_ADMIN_KEY=${AUTOCONF_ADMIN_KEY:-true}
+export OIDC_ENABLE=${OIDC_ENABLE:-false}
+export LDAP_ENABLE=${LDAP_ENABLE:-false}
+export ENABLE_DB_SETTINGS=${ENABLE_DB_SETTINGS:-false}
+export PROXY_ENABLE=${PROXY_ENABLE:-false}
+export DEBUG=${DEBUG:-0}
+
 # start supervisord using the main configuration file so we have a socket interface
 /usr/bin/supervisord -c /etc/supervisor/supervisord.conf

--- a/core/files/entrypoint_cron.sh
+++ b/core/files/entrypoint_cron.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-[ -z "$CRON_USER_ID" ] && CRON_USER_ID=1
-
 term_procs() {
     echo "Entrypoint CRON caught SIGTERM signal!"
     echo "Killing process $p1_pid"
@@ -12,7 +10,6 @@ term_procs() {
 
 trap term_procs SIGTERM
 
-# Create the misp cron tab
 cat << EOF > /etc/cron.d/misp
 20 2 * * * www-data /var/www/MISP/app/Console/cake Server cacheFeed "$CRON_USER_ID" all > /tmp/cronlog 2>&1
 30 2 * * * www-data /var/www/MISP/app/Console/cake Server fetchFeed "$CRON_USER_ID" all > /tmp/cronlog 2>&1

--- a/core/files/entrypoint_fpm.sh
+++ b/core/files/entrypoint_fpm.sh
@@ -8,9 +8,6 @@ term_proc() {
 
 trap term_proc SIGTERM
 
-[ -z "$REDIS_FQDN" ] && REDIS_FQDN=redis
-[ -z "$REDIS_PASSWORD" ] && REDIS_PASSWORD=redispassword
-
 change_php_vars() {
     for FILE in /etc/php/*/fpm/php.ini
     do
@@ -20,7 +17,7 @@ change_php_vars() {
         sed -i "s/upload_max_filesize = .*/upload_max_filesize = 50M/" "$FILE"
         sed -i "s/post_max_size = .*/post_max_size = 50M/" "$FILE"
         sed -i "s/session.save_handler = .*/session.save_handler = redis/" "$FILE"
-        sed -i "s|.*session.save_path = .*|session.save_path = '$(echo $REDIS_FQDN | grep -E '^\w+://' || echo tcp://$REDIS_FQDN):6379?auth=${REDIS_PASSWORD}'|" "$FILE"
+        sed -i "s|.*session.save_path = .*|session.save_path = '$(echo $REDIS_HOST | grep -E '^\w+://' || echo tcp://$REDIS_HOST):6379?auth=${REDIS_PASSWORD}'|" "$FILE"
         sed -i "s/session.sid_length = .*/session.sid_length = 64/" "$FILE"
         sed -i "s/session.use_strict_mode = .*/session.use_strict_mode = 1/" "$FILE"
     done

--- a/core/files/entrypoint_nginx.sh
+++ b/core/files/entrypoint_nginx.sh
@@ -8,18 +8,7 @@ term_proc() {
 
 trap term_proc SIGTERM
 
-[ -z "$MYSQL_HOST" ] && MYSQL_HOST=db
-[ -z "$MYSQL_PORT" ] && MYSQL_PORT=3306
-[ -z "$MYSQL_USER" ] && MYSQL_USER=misp
-[ -z "$MYSQL_PASSWORD" ] && MYSQL_PASSWORD=example
-[ -z "$MYSQL_DATABASE" ] && MYSQL_DATABASE=misp
-[ -z "$MYSQLCMD" ] && export MYSQLCMD="mysql -u $MYSQL_USER -p$MYSQL_PASSWORD -P $MYSQL_PORT -h $MYSQL_HOST -r -N $MYSQL_DATABASE"
-[ -z "$REDIS_PASSWORD" ] && export REDIS_PASSWORD=redispassword
-[ -z "$CRON_USER_ID" ] && export CRON_USER_ID="1"
-[ -z "$BASE_URL" ] && export BASE_URL="https://localhost"
-[ -z "$DISABLE_IPV6" ] && export DISABLE_IPV6=false
-[ -z "$DISABLE_SSL_REDIRECT" ] && export DISABLE_SSL_REDIRECT=false
-[ -z "$SMTP_FQDN" ] && export SMTP_FQDN=mail
+MYSQLCMD="mysql -u $MYSQL_USER -p$MYSQL_PASSWORD -P $MYSQL_PORT -h $MYSQL_HOST -r -N $MYSQL_DATABASE"
 
 init_mysql(){
     # Test when MySQL is ready....

--- a/core/files/etc/misp-docker/initialisation.envars.json
+++ b/core/files/etc/misp-docker/initialisation.envars.json
@@ -13,7 +13,10 @@
     "default_value": "${SETTING_CONTACT}"
   },
   "Plugin.ZeroMQ_redis_host": {
-    "default_value": "${REDIS_FQDN}"
+    "default_value": "${REDIS_HOST}"
+  },
+  "Plugin.ZeroMQ_redis_port": {
+    "default_value": "${REDIS_PORT}"
   },
   "Plugin.ZeroMQ_redis_password": {
     "default_value": "${REDIS_PASSWORD}"

--- a/core/files/etc/misp-docker/minimum_config.defaults.json
+++ b/core/files/etc/misp-docker/minimum_config.defaults.json
@@ -24,9 +24,6 @@
     "default_value": "/etc/ssl/certs/ca-certificates.crt",
     "command_args": "-f"
   },
-  "MISP.redis_port": {
-    "default_value": 6379
-  },
   "MISP.redis_database": {
     "default_value": 13
   },
@@ -63,9 +60,6 @@
   },
   "SimpleBackgroundJobs.supervisor_user": {
     "default_value": "supervisor"
-  },
-  "SimpleBackgroundJobs.redis_port": {
-    "default_value": 6379
   },
   "SimpleBackgroundJobs.redis_database": {
     "default_value": 1

--- a/core/files/etc/misp-docker/minimum_config.envars.json
+++ b/core/files/etc/misp-docker/minimum_config.envars.json
@@ -3,7 +3,10 @@
     "default_value": "${PYTHON_BIN}"
   },
   "MISP.redis_host": {
-    "default_value": "${REDIS_FQDN}"
+    "default_value": "${REDIS_HOST}"
+  },
+  "MISP.redis_port": {
+    "default_value": "${REDIS_PORT}"
   },
   "MISP.redis_password": {
     "default_value": "${REDIS_PASSWORD}"
@@ -12,7 +15,10 @@
     "default_value": "${GPG_BINARY}"
   },
   "SimpleBackgroundJobs.redis_host": {
-    "default_value": "${REDIS_FQDN}"
+    "default_value": "${REDIS_HOST}"
+  },
+  "SimpleBackgroundJobs.redis_port": {
+    "default_value": "${REDIS_PORT}"
   },
   "SimpleBackgroundJobs.redis_password": {
     "default_value": "${REDIS_PASSWORD}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,6 +160,8 @@ services:
       - "MYSQL_PASSWORD=${MYSQL_PASSWORD:-example}"
       - "MYSQL_DATABASE=${MYSQL_DATABASE:-misp}"
       # redis settings
+      - "REDIS_HOST=${REDIS_HOST:-redis}"
+      - "REDIS_PORT=${REDIS_PORT:-6379}"
       - "REDIS_PASSWORD=${REDIS_PASSWORD:-redispassword}"
       # Debug setting 
       - "DEBUG=${DEBUG}"
@@ -175,7 +177,8 @@ services:
         - MODULES_COMMIT=${MODULES_COMMIT}
         - LIBFAUP_COMMIT=${LIBFAUP_COMMIT:?Missing .env file, see README.md for instructions}
     environment:
-      - "REDIS_BACKEND=redis"
+      - "REDIS_BACKEND=${REDIS_HOST:-redis}"
+      - "REDIS_PORT=${REDIS_PORT:-6379}"
       - "REDIS_PW=${REDIS_PASSWORD:-redispassword}"
     depends_on:
       redis:

--- a/template.env
+++ b/template.env
@@ -79,6 +79,8 @@ SYNCSERVERS_1_PULL_RULES=
 # MYSQL_DATABASE=
 
 # optional and used to set redis password
+# REDIS_HOST=
+# REDIS_PORT=
 # REDIS_PASSWORD=
 
 # These variables allows overriding some MISP email values.


### PR DESCRIPTION
@UFOSmuggler We had many issues recently due to some bugs in our defaults systems, and other most destructive issues caused by MISP rejecting settings when system_db_setting is enabled.

A new release of MISP is scheduled soon, but in the meanwhile it would be good to further tests these last changes.