### PR TITLE
Run component updates in the background

### DIFF
--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -353,7 +353,9 @@ init_settings() {
 update_components() {
     UPDATE_SUDO_CMD="sudo -u www-data"
     if [ ! -z "${DB_ALREADY_INITIALISED}" ]; then
-        UPDATE_SUDO_CMD="sudo -b -u www-data"
+        if [ ! -z "${BACKGROUND_COMPONENT_UPDATES}" ]; then
+            UPDATE_SUDO_CMD="sudo -b -u www-data"
+        fi
     fi
     ${UPDATE_SUDO_CMD} /var/www/MISP/app/Console/cake Admin updateGalaxies
     ${UPDATE_SUDO_CMD} /var/www/MISP/app/Console/cake Admin updateTaxonomies

--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -351,11 +351,11 @@ init_settings() {
 }
 
 update_components() {
-    sudo -u www-data /var/www/MISP/app/Console/cake Admin updateGalaxies
-    sudo -u www-data /var/www/MISP/app/Console/cake Admin updateTaxonomies
-    sudo -u www-data /var/www/MISP/app/Console/cake Admin updateWarningLists
-    sudo -u www-data /var/www/MISP/app/Console/cake Admin updateNoticeLists
-    sudo -u www-data /var/www/MISP/app/Console/cake Admin updateObjectTemplates "$CRON_USER_ID"
+    sudo -b -u www-data /var/www/MISP/app/Console/cake Admin updateGalaxies
+    sudo -b -u www-data /var/www/MISP/app/Console/cake Admin updateTaxonomies
+    sudo -b -u www-data /var/www/MISP/app/Console/cake Admin updateWarningLists
+    sudo -b -u www-data /var/www/MISP/app/Console/cake Admin updateNoticeLists
+    sudo -b -u www-data /var/www/MISP/app/Console/cake Admin updateObjectTemplates "$CRON_USER_ID"
 }
 
 update_ca_certificates() {
@@ -431,7 +431,7 @@ echo "MISP | Init default user and organization ..." && init_user
 
 echo "MISP | Resolve critical issues ..." && apply_critical_fixes
 
-echo "MISP | Update components ..." && update_components
+echo "MISP | Start component updates (background task) ..." && update_components
 
 echo "MISP | Resolve non-critical issues ..." && apply_optional_fixes
 

--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -351,11 +351,15 @@ init_settings() {
 }
 
 update_components() {
-    sudo -b -u www-data /var/www/MISP/app/Console/cake Admin updateGalaxies
-    sudo -b -u www-data /var/www/MISP/app/Console/cake Admin updateTaxonomies
-    sudo -b -u www-data /var/www/MISP/app/Console/cake Admin updateWarningLists
-    sudo -b -u www-data /var/www/MISP/app/Console/cake Admin updateNoticeLists
-    sudo -b -u www-data /var/www/MISP/app/Console/cake Admin updateObjectTemplates "$CRON_USER_ID"
+    UPDATE_SUDO_CMD="sudo -u www-data"
+    if [ ! -z "${DB_ALREADY_INITIALISED}" ]; then
+        UPDATE_SUDO_CMD="sudo -b -u www-data"
+    fi
+    ${UPDATE_SUDO_CMD} /var/www/MISP/app/Console/cake Admin updateGalaxies
+    ${UPDATE_SUDO_CMD} /var/www/MISP/app/Console/cake Admin updateTaxonomies
+    ${UPDATE_SUDO_CMD} /var/www/MISP/app/Console/cake Admin updateWarningLists
+    ${UPDATE_SUDO_CMD} /var/www/MISP/app/Console/cake Admin updateNoticeLists
+    ${UPDATE_SUDO_CMD} /var/www/MISP/app/Console/cake Admin updateObjectTemplates "$CRON_USER_ID"
 }
 
 update_ca_certificates() {

--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -354,6 +354,7 @@ update_components() {
     UPDATE_SUDO_CMD="sudo -u www-data"
     if [ ! -z "${DB_ALREADY_INITIALISED}" ]; then
         if [ ! -z "${BACKGROUND_COMPONENT_UPDATES}" ]; then
+            echo "... updates will run in the background"
             UPDATE_SUDO_CMD="sudo -b -u www-data"
         fi
     fi
@@ -437,7 +438,7 @@ echo "MISP | Init default user and organization ..." && init_user
 
 echo "MISP | Resolve critical issues ..." && apply_critical_fixes
 
-echo "MISP | Start component updates (background task) ..." && update_components
+echo "MISP | Start component updates ..." && update_components
 
 echo "MISP | Resolve non-critical issues ..." && apply_optional_fixes
 

--- a/core/files/entrypoint_nginx.sh
+++ b/core/files/entrypoint_nginx.sh
@@ -37,6 +37,7 @@ init_mysql(){
 
     if [ $(isDBinitDone) -eq 0 ]; then
         echo "... database has already been initialized"
+        export DB_ALREADY_INITIALISED=true
     else
         echo "... database has not been initialized, importing MySQL scheme..."
         $MYSQLCMD < /var/www/MISP/INSTALL/MYSQL.sql


### PR DESCRIPTION
Currently, starting the image after bumping version numbers tends to be stuck for a very long time on component updates.

This PR runs these updates in the background rather than blocking startup waiting for the updates to be complete.

I don't really see a reason to wait for these to finish before proceeding with that we do after, and this change potentially reduces update downtime by a lot, depending on how time-consuming these processes are per update.