### PR TITLE
Add OIDC scopes environment variable

### DIFF
--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -97,7 +97,8 @@ set_up_oidc() {
                 \"client_secret\": \"${OIDC_CLIENT_SECRET}\",
                 \"roles_property\": \"${OIDC_ROLES_PROPERTY}\",
                 \"role_mapper\": ${OIDC_ROLES_MAPPING},
-                \"default_org\": \"${OIDC_DEFAULT_ORG}\"
+                \"default_org\": \"${OIDC_DEFAULT_ORG}\",
+                \"scopes\": ${OIDC_SCOPES}
             }
         }" > /dev/null
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,7 @@ services:
       - "OIDC_ROLES_MAPPING=${OIDC_ROLES_MAPPING}"
       - "OIDC_DEFAULT_ORG=${OIDC_DEFAULT_ORG}"
       - "OIDC_LOGOUT_URL=${OIDC_LOGOUT_URL}"
+      - "OIDC_SCOPES=${OIDC_SCOPES}"
       # LDAP authentication settings
       - "LDAP_ENABLE=${LDAP_ENABLE}"
       - "LDAP_APACHE_ENV=${LDAP_APACHE_ENV}"


### PR DESCRIPTION
MISP 2.5.0 added (https://github.com/MISP/MISP/pull/9912) a new OidcAuth.scopes configuration option for the reasons described in https://github.com/MISP/MISP/pull/9905.

This PR adds a new environment variable to misp-core where users can add a value of the form `["profile", "email"]` and modifies the OIDC configuration section of configure_misp.sh to configure this new option.