### PR TITLE
Fix OIDC SCOPES

### DIFF
--- a/template.env
+++ b/template.env
@@ -123,6 +123,7 @@ SYNCSERVERS_1_PULL_RULES=
 # OIDC_ROLES_MAPPING="{\"admin\": \"1\"}"
 # OIDC_DEFAULT_ORG=
 # OIDC_LOGOUT_URL=
+# OIDC_SCOPES=
 
 # Enable LDAP (using the ApacheSecureAuth component) authentication, according to https://github.com/MISP/MISP/issues/6189
 # NOTE: Once you enable LDAP authentication with the ApacheSecureAuth component, 


### PR DESCRIPTION
This modification allows the `scopes` field in the OIDC configuration to be added only if an `OIDC_SCOPES` variable is provided. For providers like Keycloak, scopes may not be mandatory, as permissions and access can be managed in other ways. Therefore, the configuration has been adjusted to make the `scopes` field optional, adding it only when needed.