### PR TITLE
Add UUID for the Admin organisation when deploying

### DIFF
--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -282,6 +282,10 @@ init_user() {
         echo "UPDATE $MYSQL_DATABASE.organisations SET name = \"${ADMIN_ORG}\" where id = 1;" | ${MYSQL_CMD}
     fi
 
+    if [ ! -z "$ADMIN_ORG_UUID" ]; then
+        echo "UPDATE $MYSQL_DATABASE.organisations SET uuid = \"${ADMIN_ORG_UUID}\" where id = 1;" | ${MYSQL_CMD}
+    fi
+
     if [ -n "$ADMIN_KEY" ]; then
         echo "... setting admin key to '${ADMIN_KEY}'"
         CHANGE_CMD=(sudo -u www-data /var/www/MISP/app/Console/cake User change_authkey 1 "${ADMIN_KEY}")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,6 +112,7 @@ services:
       - "ADMIN_PASSWORD=${ADMIN_PASSWORD}"
       - "ADMIN_KEY=${ADMIN_KEY}"
       - "ADMIN_ORG=${ADMIN_ORG}"
+      - "ADMIN_ORG_UUID=${ADMIN_ORG_UUID}"
       - "GPG_PASSPHRASE=${GPG_PASSPHRASE}"
       # OIDC authentication settings
       - "OIDC_ENABLE=${OIDC_ENABLE}"

--- a/template.env
+++ b/template.env
@@ -35,6 +35,8 @@ LIBFAUP_COMMIT=3a26d0a
 ADMIN_EMAIL=
 # name of org #1, default to MISP's default (ORGNAME)
 ADMIN_ORG=
+# uuid of org #1, defaults to an automatically generated one
+ADMIN_ORG_UUID=
 # defaults to an automatically generated one
 ADMIN_KEY=
 # defaults to MISP's default (admin)


### PR DESCRIPTION
Added a variable ADMIN_ORG_UUID which sets the UUID for the ADMIN_ORG on deployment. This is needed or migrations or other cases where a uuid for the organisation already exists.