### PR TITLE
temporary response should not enable a successful healthcheck or cache

### DIFF
--- a/core/files/var/www/html/index.php
+++ b/core/files/var/www/html/index.php
@@ -1,3 +1,10 @@
+<?php
+$proto = (isset($_SERVER['SERVER_PROTOCOL']))?($_SERVER['SERVER_PROTOCOL']):('HTTP/1.1');
+header($proto.' 503 Service Unavailable', true);
+header('cache-control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
+header('retry-after: 30');
+header('refresh: 30');
+?>
 <html>
 MISP is loading...
 </html>


### PR DESCRIPTION
the temporary response sent while additional configuration tasks are running preparing the container should not enable a successful healthcheck (thus the 503 response) or caching in upstream proxies (then the cache-control)

fixes: #185