### PR TITLE
Include rsyslog for local syslogger

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -262,6 +262,9 @@ EOF
         touch /var/www/MISP/.git/ORIG_HEAD && chmod 0600 /var/www/MISP/.git/ORIG_HEAD && chown www-data:www-data /var/www/MISP/.git/ORIG_HEAD
 EOF
 
+    # Include rsyslog to support syslogger
+    RUN apt-get update ; apt-get install -y rsyslog
+
     # Copy all our image specific files to appropriate locations
     COPY files/ /
     ENTRYPOINT [ "/entrypoint.sh" ]

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -178,6 +178,8 @@ FROM php-base
         gpg-agent \
         mariadb-client \
         rsync \
+        # Include rsyslog to support syslogger
+        rsyslog \
         # PHP Requirements
         php8.2 \
         php8.2-apcu \
@@ -261,9 +263,6 @@ EOF
         # Diagnostics wants this file to be present and writable even if we do not use git in docker land
         touch /var/www/MISP/.git/ORIG_HEAD && chmod 0600 /var/www/MISP/.git/ORIG_HEAD && chown www-data:www-data /var/www/MISP/.git/ORIG_HEAD
 EOF
-
-    # Include rsyslog to support syslogger
-    RUN apt-get update ; apt-get install -y rsyslog
 
     # Copy all our image specific files to appropriate locations
     COPY files/ /

--- a/core/files/etc/supervisor/conf.d/10-supervisor.conf
+++ b/core/files/etc/supervisor/conf.d/10-supervisor.conf
@@ -37,3 +37,12 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:rsyslog]
+command=/usr/sbin/rsyslogd -n
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+autostart=true
+autorestart=true


### PR DESCRIPTION
Possible rsyslog file can be: /etc/rsyslog.d/40-misp.conf

```
global(parser.PermitSlashInProgramname="on")

if (
    (
        $programname == '/var/www/MISP/app/tmp/logs/' or
        $programname == 'MISP-SYNC' or
        $programname == 'MISP-SCRIPTS'
    ) and not (
        $msg contains 'contracts.canonical.' or
        $msg contains 'ubuntupro.http'
    )
)

then /var/www/MISP/app/tmp/logs/mispsyslog.log

& stop
```