### PR TITLE
Remove doubled X-XSS-Protection Header

### DIFF
--- a/core/files/etc/nginx/includes/misp
+++ b/core/files/etc/nginx/includes/misp
@@ -11,7 +11,6 @@ add_header X-Download-Options "noopen" always;
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Permitted-Cross-Domain-Policies "none" always;
 add_header X-Robots-Tag "none" always;
-add_header X-XSS-Protection "1; mode=block" always;
 
 # remove X-Powered-By and nginx version, which is an information leak
 fastcgi_hide_header X-Powered-By;


### PR DESCRIPTION
since it gets already set by MISP itself. [Code](https://github.com/MISP/MISP/blob/ec91464441443e2043e5616489ac25a4ab4575b6/app/Controller/AppController.php#L160)

[OWASPs](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_1) recommendation for this header is:
> Do not set this header or explicitly turn it off. `X-XSS-Protection: 0`

![image](https://github.com/user-attachments/assets/702c7505-bac5-4ec9-973d-95baff34c785)
