### PR TITLE
Remove post-check and pre-check - discouraged IE-only Cache directives

### DIFF
--- a/core/files/var/www/html/index.php
+++ b/core/files/var/www/html/index.php
@@ -1,7 +1,7 @@
 <?php
 $proto = (isset($_SERVER['SERVER_PROTOCOL']))?($_SERVER['SERVER_PROTOCOL']):('HTTP/1.1');
 header($proto.' 503 Service Unavailable', true);
-header('cache-control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
+header('cache-control: no-store, no-cache, must-revalidate');
 header('retry-after: 30');
 header('refresh: 30');
 ?>


### PR DESCRIPTION
These old IE-only directives for Cache-Control should not be used anymore according to this:
https://stackoverflow.com/questions/34663916/are-cache-control-pre-check-and-post-check-headers-still-supported-by-ie

Having them both set to 0 should anyway never have had an effect.