### PR TITLE
fix literal folder

### DIFF
--- a/modules/Dockerfile
+++ b/modules/Dockerfile
@@ -77,6 +77,6 @@ EOF
     COPY --from=python-build /wheels /wheels
     RUN pip install --no-cache-dir /wheels/*.whl && rm -rf /wheels
     RUN pip uninstall -y pip
-    RUN mkdir -p /custom/{action_mod,expansion,export_mod,import_mod}
+    RUN bash -c 'mkdir -p /custom/{action_mod,expansion,export_mod,import_mod}'
 
     ENTRYPOINT [ "/usr/local/bin/misp-modules", "-l", "0.0.0.0", "-c", "/custom/"]


### PR DESCRIPTION
Docker uses `/bin/sh` by default, so a single folder named `{action_mod,expansion,export_mod,import_mod}` is created. 

Fix: use bash which supports brace expansion to create the folders.