### PR TITLE
Updating entrypoint_fpm.sh to fix the sed command for setting timezone.

### DIFF
--- a/core/files/entrypoint_fpm.sh
+++ b/core/files/entrypoint_fpm.sh
@@ -31,7 +31,7 @@ change_php_vars() {
         sed -i "s/session.sid_length = .*/session.sid_length = 64/" "$FILE"
         sed -i "s/session.use_strict_mode = .*/session.use_strict_mode = 1/" "$FILE"
         echo "Configure PHP | Setting 'date.timezone = ${PHP_TIMEZONE}'"
-	    sed -i -E "s|;?date.timezone =.*|date.timezone = ${PHP_TIMEZONE}|" "$FILE"
+        sed -i -E "s|;?date.timezone =.*|date.timezone = ${PHP_TIMEZONE}|" "$FILE"
     done
 
     for FILE in /etc/php/*/fpm/pool.d/www.conf

--- a/core/files/entrypoint_fpm.sh
+++ b/core/files/entrypoint_fpm.sh
@@ -31,7 +31,7 @@ change_php_vars() {
         sed -i "s/session.sid_length = .*/session.sid_length = 64/" "$FILE"
         sed -i "s/session.use_strict_mode = .*/session.use_strict_mode = 1/" "$FILE"
         echo "Configure PHP | Setting 'date.timezone = ${PHP_TIMEZONE}'"
-	sed -i -E "s|^\s*;?\s*date\.timezone\s*=.*|date.timezone = ${PHP_TIMEZONE}|" "$FILE"
+	    sed -i -E "s|;?date.timezone =.*|date.timezone = ${PHP_TIMEZONE}|" "$FILE"
     done
 
     for FILE in /etc/php/*/fpm/pool.d/www.conf

--- a/core/files/entrypoint_fpm.sh
+++ b/core/files/entrypoint_fpm.sh
@@ -31,7 +31,7 @@ change_php_vars() {
         sed -i "s/session.sid_length = .*/session.sid_length = 64/" "$FILE"
         sed -i "s/session.use_strict_mode = .*/session.use_strict_mode = 1/" "$FILE"
         echo "Configure PHP | Setting 'date.timezone = ${PHP_TIMEZONE}'"
-        sed -i "s/;?date.timezone = .*/date.timezone = ${PHP_TIMEZONE}/" "$FILE"
+	sed -i -E "s|^\s*;?\s*date\.timezone\s*=.*|date.timezone = ${PHP_TIMEZONE}|" "$FILE"
     done
 
     for FILE in /etc/php/*/fpm/pool.d/www.conf


### PR DESCRIPTION
I have been trying to update the timezone on my MISP instance to, 'Australia/Sydney' but hasn't been working.
Seems like the sed command for setting the timezone isn't working correctly.
I hand to add the -E flag and use, '|' instead of '/' in the sed command as timezone has a, '/' as well.
I tested this and this has correctly set `date.timezone` in `/etc/php/*/fpm/php.ini`