### PR TITLE
Allow automatic pushing builds to GHRC in forks

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -32,7 +32,8 @@ jobs:
         run: |
           sed -e '/^[[:space:]]*$/d' -e '/[#@]/d' -e 's/\"//g' -e 's/\(^[^=]*\)=\(.*\)/\1="\2"/' template.env > env.hcl
           echo "COMMIT_HASH=`echo '${{ github.sha }}' | cut -c 1-7`" >> "$GITHUB_ENV"
-          echo "NAMESPACE=ghcr.io/misp/misp-docker" >> "$GITHUB_ENV"
+          OWNER=$(echo "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')
+          echo "NAMESPACE=ghcr.io/${OWNER}/misp-docker" >> "$GITHUB_ENV"
 
       - name: Log in to the container registry
         uses: docker/login-action@v3


### PR DESCRIPTION
Swaps the static repo owner "misp" to the lowercase version of the current repository owner, which allows automatic building and pushing of images to GHCR within forks of the project.

Fixed from PR #267 which had mistakenly contained commits from another change.