### PR TITLE
Enable manual trigger of container build from GitHub Actions page

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -3,6 +3,7 @@ name: Build the Docker images and push them to the container registry
 on:
   push:
     branches: [ "master" ]
+  workflow_dispatch: # manual trigger
 
 jobs:
   build:


### PR DESCRIPTION
Adds a button to the workflow on the GitHub Actions page that allows manual triggering of container builds without needing empty commits.

<img width="1604" height="309" alt="image" src="https://github.com/user-attachments/assets/0b061446-d13c-47bf-b1eb-01c297c707f4" />
