### PR TITLE
Rebuilding MISP 2.5.15

### DIFF
--- a/template.env
+++ b/template.env
@@ -2,7 +2,7 @@
 # Build-time variables
 ##
 
-CORE_TAG=v2.5.15
+CORE_TAG=v2.5.16
 # CORE_FLAVOR=full
 MODULES_TAG=v3.0.2
 # MODULES_FLAVOR=full


### PR DESCRIPTION
Since MISP has release the new 2.5.16, we should build as well.