### PR TITLE
Support Selinux enabled platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ Using a slow disk as the mounted volume or a volume with high latency like NFS, 
     - `./attachments`: `/var/www/MISP/app/attachments`
 - Set the environment variable `ATTACHMENTS_DIR` to the above folder location (it is important that it doesn't replace the `/var/www/MISP/app/files/` folder). 
 
+### SELinux
+
+On systems using SELinux, volume binds are not given write permissions by default. Using the tag `:Z` or `:z` at the end of a volume bind files grants write permission through SELinux.
+
+- The `Z` option tells Docker to label the content with a private unshared label.
+- The `z` option tells Docker that two containers share the volume content.
+
 ## Installing custom root CA certificates
 
 Custom root CA certificates can be mounted under `/usr/local/share/ca-certificates` and will be installed during the `misp-core` container start.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,9 +98,9 @@ services:
       - "./ssl/:/etc/nginx/certs/:Z"
       - "./gnupg/:/var/www/MISP/.gnupg/:Z"
     # customize by replacing ${CUSTOM_PATH} with a path containing 'files/customize_misp.sh'
-      # - "${CUSTOM_PATH}/:/custom/"
+      # - "${CUSTOM_PATH}/:/custom/:Z"
       # mount custom ca root certificates
-      # - "./rootca.pem:/usr/local/share/ca-certificates/rootca.crt"
+      # - "./rootca.pem:/usr/local/share/ca-certificates/rootca.crt:Z"
     environment:
       - "BASE_URL=${BASE_URL}"
       - "CRON_USER_ID=${CRON_USER_ID}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       --innodb-stats-persistent=${INNODB_STATS_PERSISTENT:-ON} \
       --innodb-write-io-threads=${INNODB_WRITE_IO_THREADS:-4}"
     volumes:
-      - mysql_data:/var/lib/mysql
+      - mysql_data:/var/lib/mysql:Z
     cap_add:
       - SYS_NICE  # CAP_SYS_NICE Prevent runaway mysql log
     healthcheck:
@@ -92,12 +92,12 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - "./configs/:/var/www/MISP/app/Config/"
-      - "./logs/:/var/www/MISP/app/tmp/logs/"
-      - "./files/:/var/www/MISP/app/files/"
-      - "./ssl/:/etc/nginx/certs/"
-      - "./gnupg/:/var/www/MISP/.gnupg/"
-      # customize by replacing ${CUSTOM_PATH} with a path containing 'files/customize_misp.sh'
+      - "./configs/:/var/www/MISP/app/Config/:Z"
+      - "./logs/:/var/www/MISP/app/tmp/logs/:Z"
+      - "./files/:/var/www/MISP/app/files/:Z"
+      - "./ssl/:/etc/nginx/certs/:Z"
+      - "./gnupg/:/var/www/MISP/.gnupg/:Z"
+    # customize by replacing ${CUSTOM_PATH} with a path containing 'files/customize_misp.sh'
       # - "${CUSTOM_PATH}/:/custom/"
       # mount custom ca root certificates
       # - "./rootca.pem:/usr/local/share/ca-certificates/rootca.crt"
@@ -269,10 +269,11 @@ services:
       start_interval: 5s
     volumes:
       # custom MISP modules are loaded at startup time
-      - "./custom/action_mod/:/custom/action_mod/"
-      - "./custom/expansion/:/custom/expansion/"
-      - "./custom/export_mod/:/custom/export_mod/"
-      - "./custom/import_mod/:/custom/import_mod/"
+      - "./custom/action_mod/:/custom/action_mod/:Z"
+      - "./custom/expansion/:/custom/expansion/:Z"
+      - "./custom/export_mod/:/custom/export_mod/:Z"
+      - "./custom/import_mod/:/custom/import_mod/:Z"
 
 volumes:
     mysql_data:
+


### PR DESCRIPTION
Hello, I noticed, when using a Selinux enabled platform,  `docker compose up` fails to properly run the services with a `permission denied` error. 
This can be simply solved by adding the `:Z` tags to volumes mapping in `docker-compose.yml`.

I tested on Fedora42, it solved the issue for me.