### PR TITLE
Add persistence to Valkey

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       retries: 3
       start_period: 5s
       start_interval: 5s
+    volumes:
+      - cache_data:/data:Z
 
   db:
     # We use MariaDB because it supports ARM and has the expected collations
@@ -277,4 +279,5 @@ services:
 
 volumes:
     mysql_data:
+    cache_data:
 


### PR DESCRIPTION
Valkey is [configured by default][1] to persist data on disk, so we only need the volume configure to keep it between container recreation. The container has already [the required directory][2].

Fixes #298

[1]: https://valkey.io/topics/persistence/#no-persistence
[2]: https://hub.docker.com/r/valkey/valkey/#start-with-persistent-storage