### PR TITLE
add: allow to set MISP_IP via environment variable

### DIFF
--- a/guard/files/entrypoint.sh
+++ b/guard/files/entrypoint.sh
@@ -15,7 +15,9 @@
 set -e
 
 # resolve misp-core from docker dns
-MISP_IP=$(getent hosts misp-core | awk '{print $1}')
+if [ -z "$MISP_IP" ]; then
+  MISP_IP=$(getent hosts misp-core | awk '{print $1}')
+fi
 
 # replace runtime ip into config.json
 jq --arg ip "$MISP_IP" \


### PR DESCRIPTION
This allows to run the `misp-docker/misp-guard` standalone or in scenarios where you you don't have a `misp-core` host in your docker network.

Example:
```
docker run --name misp-guard \
  -e MISP_IP=172.19.0.7 \
  -e GUARD_PORT=8888 \
  -e GUARD_ARGS="--ssl-insecure -v" \
  -p 8888:8888 \
  -v /home/user/misp-guard/src/config.json:/config.json:ro \
  ghcr.io/misp/misp-docker/misp-guard:latest
```

See: https://github.com/MISP/misp-guard?tab=readme-ov-file#docker