### PR TITLE
Improve errror message for env file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,10 +60,10 @@ services:
     build:
       context: core/.
       args:
-          - CORE_TAG=${CORE_TAG:?Missing .env file, see README.md for instructions}
+          - CORE_TAG=${CORE_TAG:?Missing or outdated .env file, see README.md for instructions}
           - CORE_COMMIT=${CORE_COMMIT}
           - CORE_FLAVOR=${CORE_FLAVOR:-full}
-          - PHP_VER=${PHP_VER:?Missing .env file, see README.md for instructions}
+          - PHP_VER=${PHP_VER:?Missing or outdated .env file, see README.md for instructions}
           - PYPI_REDIS_VERSION=${PYPI_REDIS_VERSION}
           - PYPI_LIEF_VERSION=${PYPI_LIEF_VERSION}
           - PYPI_PYDEEP2_VERSION=${PYPI_PYDEEP2_VERSION}
@@ -261,7 +261,7 @@ services:
     build:
       context: modules/.
       args:
-        - MODULES_TAG=${MODULES_TAG:?Missing .env file, see README.md for instructions}
+        - MODULES_TAG=${MODULES_TAG:?Missing or outdated .env file, see README.md for instructions}
         - MODULES_COMMIT=${MODULES_COMMIT}
         - MODULES_FLAVOR=${MODULES_FLAVOR:-full}
     healthcheck:
@@ -285,7 +285,7 @@ services:
     build:
       context: guard/.
       args:
-        - GUARD_TAG=${GUARD_TAG:?Missing .env file, see README.md for instructions}
+        - GUARD_TAG=${GUARD_TAG:?Missing or outdated .env file, see README.md for instructions}
         - GUARD_COMMIT=${GUARD_COMMIT}
     depends_on:
       - misp-core


### PR DESCRIPTION
I got confused when it said that the .env file was missing but it was just missing the new var from misp-guard. I think this message will avoid some confusion for users.