### PR TITLE
Allow to configure the exposed port for the core container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,8 +91,8 @@ services:
       start_period: 30s
       start_interval: 30s
     ports:
-      - "80:80"
-      - "443:443"
+      - "${CORE_HTTP_PORT:-80}:80"
+      - "${CORE_HTTPS_PORT:-443}:443"
     volumes:
       - "./configs/:/var/www/MISP/app/Config/:Z"
       - "./logs/:/var/www/MISP/app/tmp/logs/:Z"

--- a/template.env
+++ b/template.env
@@ -58,6 +58,9 @@ CRON_USER_ID=
 # defaults to 'https://localhost'
 # note: if you are exposing MISP on a non-standard port (i.e., the port is part of the URL you would use to access it, e.g., https://192.168.0.1:4433) you need to include the port in the BASE_URL variable
 BASE_URL=
+# defaults to 80 and 443, don't forget to update the base url if not the defaults one
+CORE_HTTP_PORT=
+CORE_HTTPS_PORT=
 # store settings in db except those that must stay in config.php. true/false, defaults to false
 ENABLE_DB_SETTINGS=
 # encryption key. defaults to empty string

--- a/template.env
+++ b/template.env
@@ -59,8 +59,8 @@ CRON_USER_ID=
 # note: if you are exposing MISP on a non-standard port (i.e., the port is part of the URL you would use to access it, e.g., https://192.168.0.1:4433) you need to include the port in the BASE_URL variable
 BASE_URL=
 # defaults to 80 and 443, don't forget to update the base url if not the defaults one
-CORE_HTTP_PORT=
-CORE_HTTPS_PORT=
+# CORE_HTTP_PORT=
+# CORE_HTTPS_PORT=
 # store settings in db except those that must stay in config.php. true/false, defaults to false
 ENABLE_DB_SETTINGS=
 # encryption key. defaults to empty string


### PR DESCRIPTION
Simple config to allow other exposed port than default one (like for a rootless podman use).

Next steps could be to have other port inside the container and automatically update the base url if possible. But I need to check the impact.