### PR TITLE
Remove docker hub dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - "SMARTHOST_ALIASES=${SMARTHOST_ALIASES}"
 
   redis:
-    image: valkey/valkey:7.2
+    image: ghcr.io/valkey-io/valkey:7.2.11
     restart: always
     command: |
       sh -c '
@@ -50,7 +50,7 @@ services:
 
   db:
     # We use MariaDB because it supports ARM and has the expected collations
-    image: mariadb:10.11
+    image: ghcr.io/mariadb/mariadb:11.8.3-ubi9
     restart: always
     environment:
       - "MYSQL_USER=${MYSQL_USER:-misp}"


### PR DESCRIPTION
Requires work since mariadb does not push arm64 images to ghcr just as yet.