### PR TITLE
Add SES Configuration for SMTP

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,13 @@ services:
     image: ghcr.io/egos-tech/smtp:1.1.3
     restart: always
     environment:
+      # Amazon SES
+      - "SES_USER=${SES_USER}"
+      - "SES_PASSWORD=${SES_PASSWORD}"
+      - "SES_REGION=${SES_REGION}"
+      - "SES_PORT=${SES_PORT}"
+      - "MAILNAME=${MAILNAME}"
+      # Generic Mail (default)
       - "SMARTHOST_ADDRESS=${SMARTHOST_ADDRESS}"
       - "SMARTHOST_PORT=${SMARTHOST_PORT}"
       - "SMARTHOST_USER=${SMARTHOST_USER}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,13 +5,12 @@ services:
     image: ghcr.io/egos-tech/smtp:1.1.3
     restart: always
     environment:
-      # Amazon SES
+      # For use with Amazon SES relay
       - "SES_USER=${SES_USER}"
       - "SES_PASSWORD=${SES_PASSWORD}"
       - "SES_REGION=${SES_REGION}"
       - "SES_PORT=${SES_PORT}"
-      - "MAILNAME=${MAILNAME}"
-      # Generic Mail (default)
+      # Generic SMTP relay
       - "SMARTHOST_ADDRESS=${SMARTHOST_ADDRESS}"
       - "SMARTHOST_PORT=${SMARTHOST_PORT}"
       - "SMARTHOST_USER=${SMARTHOST_USER}"

--- a/template.env
+++ b/template.env
@@ -86,15 +86,13 @@ SMARTHOST_USER=
 SMARTHOST_PASSWORD=
 SMARTHOST_ALIASES=
 
-# optional - if you wish to use AWS SES relay INSTEAD of SMTP
-# SES_USER="
+# optional AWS SES SMTP relay settings (use these instead of the generic smarthost)
+# SES_USER=
 # SES_PASSWORD=
 # aws region (e.g., us-east-1)
 # SES_REGION=
 # default ses port is 587
 # SES_PORT=
-# from mail name, required for SES (e.g., misp.cloud.com)
-# MAILNAME=
 
 # optional comma separated list of IDs of syncservers (e.g. SYNCSERVERS=1)
 # For this to work ADMIN_KEY must be set, or AUTOGEN_ADMIN_KEY must be true (default)

--- a/template.env
+++ b/template.env
@@ -86,6 +86,16 @@ SMARTHOST_USER=
 SMARTHOST_PASSWORD=
 SMARTHOST_ALIASES=
 
+# optional - if you wish to use AWS SES relay INSTEAD of SMTP
+# SES_USER="
+# SES_PASSWORD=
+# aws region (e.g., us-east-1)
+# SES_REGION=
+# default ses port is 587
+# SES_PORT=
+# from mail name, required for SES (e.g., misp.cloud.com)
+# MAILNAME=
+
 # optional comma separated list of IDs of syncservers (e.g. SYNCSERVERS=1)
 # For this to work ADMIN_KEY must be set, or AUTOGEN_ADMIN_KEY must be true (default)
 SYNCSERVERS=


### PR DESCRIPTION
Adds optional AWS SES SMTP variables to `docker-compose.yml`, based on implementation in [egos-tech/smtp](https://gitlab.com/egos-tech/smtp/-/blob/main/docker-compose.yml). 

Tested with SES in AWS and currently running in production.