### PR TITLE
Update container image version in Kubernetes manifests and remove non-existent configmap reference

### DIFF
--- a/kubernetes/manifests/deployment-misp.yaml
+++ b/kubernetes/manifests/deployment-misp.yaml
@@ -24,7 +24,7 @@ spec:
         - name: misp
           command: 
             - /kubernetes/entrypoint_fpm.sh
-          image: "ghcr.io/misp/misp-docker/misp-core:v2.5.25"
+          image: "ghcr.io/misp/misp-docker/misp-core:latest"
           imagePullPolicy: IfNotPresent
           readinessProbe:
             tcpSocket:
@@ -77,7 +77,7 @@ spec:
             requests:
               memory: 128Mi
               cpu: 20m
-          image: "ghcr.io/misp/misp-docker/misp-modules:v3.0.2"
+          image: "ghcr.io/misp/misp-docker/misp-modules:latest"
           imagePullPolicy: IfNotPresent
           readinessProbe:
             tcpSocket:

--- a/kubernetes/manifests/deployment-misp.yaml
+++ b/kubernetes/manifests/deployment-misp.yaml
@@ -24,7 +24,7 @@ spec:
         - name: misp
           command: 
             - /kubernetes/entrypoint_fpm.sh
-          image: "ghcr.io/misp/misp-docker/misp-core:v2.5.21"
+          image: "ghcr.io/misp/misp-docker/misp-core:v2.5.25"
           imagePullPolicy: IfNotPresent
           readinessProbe:
             tcpSocket:

--- a/kubernetes/manifests/deployment-nginx.yaml
+++ b/kubernetes/manifests/deployment-nginx.yaml
@@ -24,7 +24,7 @@ spec:
         - name: nginx
           command:
             - /kubernetes/entrypoint_nginx.sh
-          image: "ghcr.io/misp/misp-docker/misp-core:v2.5.21"
+          image: "ghcr.io/misp/misp-docker/misp-core:v2.5.25"
           imagePullPolicy: IfNotPresent
           readinessProbe:
             tcpSocket:
@@ -48,13 +48,13 @@ spec:
             requests:
               memory: 512Mi
               cpu: 50m
-          volumeMounts:
-            - mountPath: /etc/nginx/certs/dhparams.pem
-              name: dhparams
-              subPath: dhparams.pem
-      volumes:
-        - configMap:
-            name: dhparams
-          name: dhparams
+      #     volumeMounts:
+      #       - mountPath: /etc/nginx/certs/dhparams.pem
+      #         name: dhparams
+      #         subPath: dhparams.pem
+      # volumes:
+      #   - configMap:
+      #       name: dhparams
+      #     name: dhparams
 
 

--- a/kubernetes/manifests/deployment-nginx.yaml
+++ b/kubernetes/manifests/deployment-nginx.yaml
@@ -24,7 +24,7 @@ spec:
         - name: nginx
           command:
             - /kubernetes/entrypoint_nginx.sh
-          image: "ghcr.io/misp/misp-docker/misp-core:v2.5.25"
+          image: "ghcr.io/misp/misp-docker/misp-core:latest"
           imagePullPolicy: IfNotPresent
           readinessProbe:
             tcpSocket:
@@ -48,13 +48,6 @@ spec:
             requests:
               memory: 512Mi
               cpu: 50m
-      #     volumeMounts:
-      #       - mountPath: /etc/nginx/certs/dhparams.pem
-      #         name: dhparams
-      #         subPath: dhparams.pem
-      # volumes:
-      #   - configMap:
-      #       name: dhparams
-      #     name: dhparams
+
 
 


### PR DESCRIPTION
Hey There!

We are working on deploying MISP into our Kubernetes cluster, and using the manifests in this repo as an example, we ran into two issues with them that I figure id contribute upstream:

- First, the manifests set a custom entry point for the php and nginx container of `/kubernetes/entrypoint_fpm.sh` and `/kubernetes/entrypoint_nginx.sh` respectively, but the image version used in the example does not have these files inside the container. I updated to `v2.5.25` and that resolved the problem
- The MISP NGINX manifest also tries to mount a `dhparams` configMap that does not seem to exist. There is no mention of this needing to be generated in the docs, so I commented it out.

Let me know if I need to make any adjustments, thanks!