### PR TITLE
#344 Fix incorrect admin user auth key regeneration

### DIFF
--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -359,8 +359,13 @@ init_user() {
         fi
         CHANGE_CMD=(sudo -u www-data /var/www/MISP/app/Console/cake User change_authkey 1 "${ADMIN_KEY}")
     elif [ -z "$ADMIN_KEY" ] && [ "$AUTOGEN_ADMIN_KEY" == "true" ]; then
-        echo "... regenerating admin key (set \$ADMIN_KEY if you want it to change)"
-        CHANGE_CMD=(sudo -u www-data /var/www/MISP/app/Console/cake User change_authkey 1)
+        HAS_VALID_KEY=$($MYSQL_CMD -N -s -e 'SELECT EXISTS(SELECT 1 FROM auth_keys WHERE user_id = 1 AND (expiration = 0 OR expiration > UNIX_TIMESTAMP()));')
+	if (( HAS_VALID_KEY == 0 )); then
+            echo "... regenerating admin key (set \$ADMIN_KEY if you want it to change)"
+            CHANGE_CMD=(sudo -u www-data /var/www/MISP/app/Console/cake User change_authkey 1)
+	else
+	    echo "... valid admin key for admin user found, not changing"
+	fi
     else
         echo "... admin user key auto generation disabled"
     fi


### PR DESCRIPTION
This closes #344 by checking whether or not a valid auth key exists for user 1.

We do `SELECT EXISTS(SELECT 1 FROM auth_keys WHERE user_id = 1 AND (expiration = 0 OR expiration > UNIX_TIMESTAMP()));` which checks for non-expiring and non-expired auth keys for user 1, and returns 0 or 1 based on whether there is a valid auth key.

If there is a valid auth key, we skip regeneration and emit a log line.

There appears to be no cake console command to check the existence of a valid auth key (we can test keys, but not see if a valid one exists) so checking the DB seems to be the way to go.

valid key exists:
```
misp-core-1  | Enforcing initialisation setting 'MISP.contact' to env var or default value 'admin@admin.test'...
misp-core-1  | Enforcing initialisation setting 'MISP.email' to env var or default value 'admin@admin.test'...
misp-core-1  | Enforcing gpg setting 'GnuPG.email' to env var or default value 'admin@admin.test'...
misp-core-1  | ... valid admin key for admin user found, not changing
```

no valid key exists:
```
misp-core-1  | Enforcing initialisation setting 'MISP.contact' to env var or default value 'admin@admin.test'...
misp-core-1  | Enforcing initialisation setting 'MISP.email' to env var or default value 'admin@admin.test'...
misp-core-1  | Enforcing gpg setting 'GnuPG.email' to env var or default value 'admin@admin.test'...
misp-core-1  | ... regenerating admin key (set $ADMIN_KEY if you want it to change)
misp-core-1  | ... admin user key set to 'UeIKSNF8X2oQ1FFGA3Xxvdwt4NKqJIO3vH6n6HpD'
```