### PR TITLE
Enable update_user_role property for Docker Image

### DIFF
--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -101,7 +101,8 @@ set_up_oidc() {
                 \"default_org\": \"${OIDC_DEFAULT_ORG}\",
                 \"mixedAuth\": ${OIDC_MIXEDAUTH},
                 \"authentication_method\": \"${OIDC_AUTH_METHOD}\",
-                \"redirect_uri\": \"${OIDC_REDIRECT_URI}\"                
+                \"redirect_uri\": \"${OIDC_REDIRECT_URI}\",
++               \"update_user_role\": ${OIDC_UPDATE_USER_ROLE}                
             }
         }" > /dev/null
 


### PR DESCRIPTION
## This change lets users of the image define one new envars:
OIDC_UPDATE_USER_ROLE = true | false

This sets the update_user_role value in the MISP config.php that is used by newer versions to allow the management of user-roles to occur internal of the application vs through role mapping.

## Why would you want this?
This is to bring the image params in-line with the allowed configuration of the parent MISP application.
