### PR TITLE
Fixed duplicate label declaration

### DIFF
--- a/kubernetes/helm-chart/templates/_helpers.tpl
+++ b/kubernetes/helm-chart/templates/_helpers.tpl
@@ -65,8 +65,6 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels for MISP
 */}}
 {{- define "misp.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "misp.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/component: "misp"
 app.kubernetes.io/part-of: {{ include "misp.name" . }}
 {{- end }}

--- a/kubernetes/helm-chart/templates/deployment.yaml
+++ b/kubernetes/helm-chart/templates/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ include "misp.fullname" . }}
   labels:
-    {{- include "common.labels.standard" . | nindent 4 }}
     {{- include "misp.labels" . | nindent 4 }}
     {{- if .Values.misp.isCore.enabled }}
     misp-type: "core"


### PR DESCRIPTION
The labels `app.kubernetes.io/instance: release-name` and `app.kubernetes.io/name: release-name` are duplicated on certain objects when built from the current Helm chart build, even with an empty values file. This removes the lines that cause this duplication from the Helm chart.