### PR TITLE
fix: mount misp-guard/mitmproxy ca in misp-core

### DIFF
--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -466,6 +466,15 @@ update_ca_certificates() {
     fi
 }
 
+configure_misp_guard_ca() {
+    if [[ "$COMPOSE_PROFILES" = "misp-guard" ]]; then
+        echo "... configuring misp-guard CA certificate"
+        chown www-data:www-data /usr/local/share/ca-certificates/misp_guard/mitmproxy-ca.pem
+        sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q "MISP.ca_path" "/usr/local/share/ca-certificates/misp_guard/mitmproxy-ca.pem"
+    fi
+}
+
+
 create_sync_servers() {
     if [ -z "$ADMIN_KEY" ]; then
         echo "... admin key auto configuration is required to configure sync servers"
@@ -630,6 +639,8 @@ echo "MISP | Set Up Session ..." && set_up_session
 echo "MISP | Set Up Proxy ..." && set_up_proxy
 
 echo "MISP | Create default Scheduled Tasks ..." && create_default_scheduled_tasks
+
+echo "MISP | Configure misp-guard CA certificate ..." && configure_misp_guard_ca
 
 echo "MISP | Mark instance live" && print_version
 sudo -u www-data /var/www/MISP/app/Console/cake Admin live 1

--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -474,7 +474,6 @@ configure_misp_guard_ca() {
     fi
 }
 
-
 create_sync_servers() {
     if [ -z "$ADMIN_KEY" ]; then
         echo "... admin key auto configuration is required to configure sync servers"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,6 +126,7 @@ services:
       - "./files/:/var/www/MISP/app/files/:Z"
       - "./ssl/:/etc/nginx/certs/:Z"
       - "./gnupg/:/var/www/MISP/.gnupg/:Z"
+      - "misp_guard_ca:/usr/local/share/ca-certificates/misp_guard:Z"
     # customize by replacing ${CUSTOM_PATH} with a path containing 'files/customize_misp.sh'
     # - "${CUSTOM_PATH}/:/custom/:Z"
     # mount custom ca root certificates
@@ -304,6 +305,8 @@ services:
       - "HSTS_MAX_AGE=${HSTS_MAX_AGE}"
       - "X_FRAME_OPTIONS=${X_FRAME_OPTIONS}"
       - "CONTENT_SECURITY_POLICY=${CONTENT_SECURITY_POLICY}"
+      # compose profiles
+      - "COMPOSE_PROFILES=${COMPOSE_PROFILES}"
 
   misp-modules:
     image: ghcr.io/misp/misp-docker/misp-modules:${MODULES_RUNNING_TAG:-latest}
@@ -347,6 +350,7 @@ services:
       - "GUARD_ARGS=${GUARD_ARGS}"
     volumes:
       - ./guard/config.json:/config.json:ro
+      - misp_guard_ca:/misp_guard_ca
     healthcheck:
       test: "/bin/bash -c '</dev/tcp/localhost/${GUARD_PORT:-8888}'"
       interval: 2m
@@ -357,3 +361,4 @@ services:
 volumes:
   mysql_data:
   cache_data:
+  misp_guard_ca:


### PR DESCRIPTION
if mitmproxy ca is not configured in `misp-core` proxied requests are dropped by the client.
this PR autoconfigures mitmproxy ca inside `misp-core` at startup

fixes https://github.com/MISP/misp-docker/issues/365