### PR TITLE
Allow for a registry mirror

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - "SMARTHOST_ALIASES=${SMARTHOST_ALIASES}"
 
   redis:
-    image: valkey/valkey:7.2
+    image: ${REGISTRY_MIRROR_URL:-}valkey/valkey:7.2
     restart: always
     command: |
       sh -c '
@@ -50,7 +50,7 @@ services:
 
   db:
     # We use MariaDB because it supports ARM and has the expected collations
-    image: mariadb:10.11
+    image: ${REGISTRY_MIRROR_URL:-}mariadb:10.11
     restart: always
     environment:
       - "MYSQL_USER=${MYSQL_USER:-misp}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   # This is capable to relay via gmail, Amazon SES, or generic relays
   # See: https://gitlab.com/egos-tech/smtp
   mail:
-    image: ghcr.io/egos-tech/smtp:1.1.3
+    image: ${REGISTRY_MIRROR_URL:-}ghcr.io/egos-tech/smtp:1.1.3
     restart: always
     environment:
       # For use with Amazon SES relay
@@ -79,7 +79,7 @@ services:
       start_interval: 5s
 
   misp-core:
-    image: ghcr.io/misp/misp-docker/misp-core:${CORE_RUNNING_TAG:-latest}
+    image: ${REGISTRY_MIRROR_URL:-}ghcr.io/misp/misp-docker/misp-core:${CORE_RUNNING_TAG:-latest}
     restart: always
     cap_add:
       - AUDIT_WRITE
@@ -310,7 +310,7 @@ services:
       - "COMPOSE_PROFILES=${COMPOSE_PROFILES}"
 
   misp-modules:
-    image: ghcr.io/misp/misp-docker/misp-modules:${MODULES_RUNNING_TAG:-latest}
+    image: ${REGISTRY_MIRROR_URL:-}ghcr.io/misp/misp-docker/misp-modules:${MODULES_RUNNING_TAG:-latest}
     restart: always
     build:
       context: modules/.
@@ -336,7 +336,7 @@ services:
     profiles:
       - misp-guard
     restart: always
-    image: ghcr.io/misp/misp-docker/misp-guard:${GUARD_RUNNING_TAG:-latest}
+    image: ${REGISTRY_MIRROR_URL:-}ghcr.io/misp/misp-docker/misp-guard:${GUARD_RUNNING_TAG:-latest}
     build:
       context: guard/.
       args:

--- a/template.env
+++ b/template.env
@@ -39,6 +39,9 @@ PYPI_SUPERVISOR_VERSION="==4.2.5"
 # MODULES_RUNNING_TAG=latest
 # GUARD_RUNNING_TAG=latest
 
+# optional: use a registry mirror for docker images
+# REGISTRY_MIRROR_URL=
+
 # Email/username for user #1, defaults to MISP's default (admin@admin.test)
 ADMIN_EMAIL=
 # name of org #1, default to MISP's default (ORGNAME)

--- a/template.env
+++ b/template.env
@@ -39,7 +39,7 @@ PYPI_SUPERVISOR_VERSION="==4.2.5"
 # MODULES_RUNNING_TAG=latest
 # GUARD_RUNNING_TAG=latest
 
-# optional: use a registry mirror for docker images
+# optional: use a registry mirror for docker images (include trailing slash, e.g., internal.mirror.com/)
 # REGISTRY_MIRROR_URL=
 
 # Email/username for user #1, defaults to MISP's default (admin@admin.test)


### PR DESCRIPTION
docker supports `registry-mirror` only for Dockerhub images and not for other domains / registries. If you use a package mirror for other registries, you have to change the image name from `ghcr.io/xxxx` to `registry-mirror/ghcr.io/xxxx`. To avoid having to change the original docker-compose.yml or override it with a `.override.yml` file and keep the versions in sync, this change adds a `REGISTRY_MIRROR_URL` env variable to specify an optional registry mirror. If not defined it defaults to an empty string resulting in the original image name.

Example:

Without `REGISTRY_MIRROR_URL`:

```
ghcr.io/egos-tech/smtp:1.1.3
```

With `REGISTRY_MIRROR_URL=internal.mirror.com/`:

```
internal.mirror.com/ghcr.io/egos-tech/smtp:1.1.3
```