### PR TITLE
enable php-fpm status page on kubernetes deployment 

### DIFF
--- a/core/files/entrypoint_fpm.sh
+++ b/core/files/entrypoint_fpm.sh
@@ -69,8 +69,13 @@ change_php_vars() {
         if [[ "$FASTCGI_STATUS_LISTEN" != "" ]]; then
             echo "Configure PHP | Setting 'pm.status_path = /status'"
             sed -i -E "s/;?pm.status_path = .*/pm.status_path = \/status/" "$FILE"
-            echo "Configure PHP | Setting 'pm.status_path = /run/php/php-fpm-status.sock'"
-            sed -i -E "s/;?pm.status_listen = .*/pm.status_listen = \/run\/php\/php-fpm-status.sock/" "$FILE"
+            if [[ -n "$PHP_LISTEN_FPM" ]]; then
+                echo "Configure PHP | Setting 'pm.status_listen' to [::]:9003"
+                sed -i -E "s/;?pm.status_listen = .*/pm.status_listen = [::]:9003/" "$FILE"
+            else
+                echo "Configure PHP | Setting 'pm.status_listen = /run/php/php-fpm-status.sock'"
+                sed -i -E "s/;?pm.status_listen = .*/pm.status_listen = \/run\/php\/php-fpm-status.sock/" "$FILE"
+            fi
         else
             echo "Configure PHP | Disabling 'pm.status_path'"
             sed -i -E "s/^pm.status_path = /;pm.status_path = /" "$FILE"

--- a/core/files/kubernetes/entrypoint_nginx.sh
+++ b/core/files/kubernetes/entrypoint_nginx.sh
@@ -9,6 +9,11 @@ echo "INIT | Initialize NGINX ..." && init_nginx
 echo "... setting 'fastcgi_pass' to misp-php:9002"
 sed -i "s@fastcgi_pass .*;@fastcgi_pass misp-php:9002;@" /etc/nginx/includes/misp
 
+if [ "$FASTCGI_STATUS_LISTEN" != "" ]; then
+    echo "... setting php-fpm status 'fastcgi_pass' to misp-php:9003"
+    sed -i "s@fastcgi_pass .*;@fastcgi_pass misp-php:9003;@" /etc/nginx/sites-enabled/php-fpm-status
+fi
+
 echo "INIT | Flip NGINX live ..." && flip_nginx true false
 
 # launch nginx as current shell process in container


### PR DESCRIPTION
On clustered deployments (where nginx and php-fpm are on separate containers) file sockets cannot be used. 

This adjustment uses the existing env set on `kubernetes/entrypoint_fpm.sh`: `PHP_LISTEN_FPM=true` to switch from file sockets to network ones (listening on port 9003).

I did not update the example deployment files as this is an optional configuration.