### PR TITLE
Repair config files if they are zero bytes

### DIFF
--- a/core/files/entrypoint_nginx.sh
+++ b/core/files/entrypoint_nginx.sh
@@ -97,13 +97,13 @@ init_misp_data_files(){
     # [ -f $MISP_APP_CONFIG_PATH/config.php ] || cp $MISP_APP_CONFIG_PATH.dist/config.default.php $MISP_APP_CONFIG_PATH/config.php
     # [ -f $MISP_APP_CONFIG_PATH/email.php ] || cp $MISP_APP_CONFIG_PATH.dist/email.php $MISP_APP_CONFIG_PATH/email.php
     # [ -f $MISP_APP_CONFIG_PATH/routes.php ] || cp $MISP_APP_CONFIG_PATH.dist/routes.php $MISP_APP_CONFIG_PATH/routes.php
-    [ -f $MISP_APP_CONFIG_PATH/bootstrap.php ] || dd if=$MISP_APP_CONFIG_PATH.dist/bootstrap.default.php of=$MISP_APP_CONFIG_PATH/bootstrap.php
-    [ -f $MISP_APP_CONFIG_PATH/database.php ] || dd if=$MISP_APP_CONFIG_PATH.dist/database.default.php of=$MISP_APP_CONFIG_PATH/database.php
-    [ -f $MISP_APP_CONFIG_PATH/core.php ] || dd if=$MISP_APP_CONFIG_PATH.dist/core.default.php of=$MISP_APP_CONFIG_PATH/core.php
-    [ -f $MISP_APP_CONFIG_PATH/config.php.template ] || dd if=$MISP_APP_CONFIG_PATH.dist/config.default.php of=$MISP_APP_CONFIG_PATH/config.php.template
-    [ -f $MISP_APP_CONFIG_PATH/config.php ] || echo -e "<?php\n\$config=array();\n?>" > $MISP_APP_CONFIG_PATH/config.php
-    [ -f $MISP_APP_CONFIG_PATH/email.php ] || dd if=$MISP_APP_CONFIG_PATH.dist/email.php of=$MISP_APP_CONFIG_PATH/email.php
-    [ -f $MISP_APP_CONFIG_PATH/routes.php ] || dd if=$MISP_APP_CONFIG_PATH.dist/routes.php of=$MISP_APP_CONFIG_PATH/routes.php
+    [ -s $MISP_APP_CONFIG_PATH/bootstrap.php ] || dd if=$MISP_APP_CONFIG_PATH.dist/bootstrap.default.php of=$MISP_APP_CONFIG_PATH/bootstrap.php
+    [ -s $MISP_APP_CONFIG_PATH/database.php ] || dd if=$MISP_APP_CONFIG_PATH.dist/database.default.php of=$MISP_APP_CONFIG_PATH/database.php
+    [ -s $MISP_APP_CONFIG_PATH/core.php ] || dd if=$MISP_APP_CONFIG_PATH.dist/core.default.php of=$MISP_APP_CONFIG_PATH/core.php
+    [ -s $MISP_APP_CONFIG_PATH/config.php.template ] || dd if=$MISP_APP_CONFIG_PATH.dist/config.default.php of=$MISP_APP_CONFIG_PATH/config.php.template
+    [ -s $MISP_APP_CONFIG_PATH/config.php ] || echo -e "<?php\n\$config=array();\n?>" > $MISP_APP_CONFIG_PATH/config.php
+    [ -s $MISP_APP_CONFIG_PATH/email.php ] || dd if=$MISP_APP_CONFIG_PATH.dist/email.php of=$MISP_APP_CONFIG_PATH/email.php
+    [ -s $MISP_APP_CONFIG_PATH/routes.php ] || dd if=$MISP_APP_CONFIG_PATH.dist/routes.php of=$MISP_APP_CONFIG_PATH/routes.php
 
     if ! grep -q "Detect what auth modules" "$MISP_APP_CONFIG_PATH/bootstrap.php"; then
         echo "... patch bootstrap.php settings"


### PR DESCRIPTION
I did a dumb and truncated the config.php file on one of my test misps, and assumed that just bouncing the container would cause it to rebuild.  However, instead all I got was a log of lots of errors.

Turns out we do [tests](https://tldp.org/LDP/abs/html/fto.html) of `[ -f /blah/config.php ]` just to see if the file exists.
We could instead test as `[ -s /blah/config.php ]` which will test it exists and is not zero bytes.

If the file does not exist or is zero bytes, we do the first run routine again to recreate them.

This PR contains that change for all /var/www/MISP/app/Config/ files.

Before change:
```
root@ocp:/home/davidz/stuff/misp-docker/configs# ll config.php
-rw------- 1 www-data www-data 4771 Mar  5 15:41 config.php
root@ocp:/home/davidz/stuff/misp-docker/configs# >config.php
root@ocp:/home/davidz/stuff/misp-docker/configs# ll config.php
-rw------- 1 www-data www-data 0 Mar  5 15:41 config.php
root@ocp:/home/davidz/stuff/misp-docker/configs# docker restart misp-docker-misp-core-1
misp-docker-misp-core-1
<wait a while...>
root@ocp:/home/davidz/stuff/misp-docker/configs# ll config.php
-rw------- 1 www-data www-data 0 Mar  5 15:41 config.php
```

After change:
```
root@ocp:/home/davidz/stuff/misp-docker/configs# ll config.php
-rw-------  1 www-data www-data  4771 Mar  5 15:32 config.php
root@ocp:/home/davidz/stuff/misp-docker/configs# >config.php
root@ocp:/home/davidz/stuff/misp-docker/configs# ll config.php
-rw-------  1 www-data www-data     0 Mar  5 15:32 config.php
root@ocp:/home/davidz/stuff/misp-docker/configs# docker restart misp-docker-misp-core-1
misp-docker-misp-core-1
<wait a while...>
root@ocp:/home/davidz/stuff/misp-docker/configs# ll config.php
-rw------- 1 www-data www-data 4771 Mar  5 15:33 config.php
```

I also tested to see if the file was the same between rebuilds.  It turns out if you do not statically set Security.salt (for which there is no envar to set), MISP makes you a new one, which is not ideal.  

Still, everything in my test instance worked including auth, so I am unsure what Security.salt does at this point.  I spent a few minutes looking through the code and I am not convinced it does anything.

For this reason I feel two ways about this PR, BUT you end up with more of your config than you did before you accidentally truncated it.

You could also obviously achieve the exact same effect this PR introduces by just deleting the truncated file.