### PR TITLE
Enable nginx to read the folders on /var/www/MISP/app/webroot

### DIFF
--- a/kubernetes/manifests/nginx-cm.yaml
+++ b/kubernetes/manifests/nginx-cm.yaml
@@ -4,6 +4,7 @@ metadata:
   name: nginx-conf
 data:
   nginx.conf: |
+    user www-data;
     worker_processes auto;
     worker_cpu_affinity auto;
     pid /tmp/nginx.pid;


### PR DESCRIPTION
By default nginx on this distro will spawn the workers with the user `nobody` instead of `www-data`, so this new user must be explicitly set at `/etc/nginx/nginx.conf`.

Not doing so will result only in *404 Not Found* error pages