### PR TITLE
Add the DISABLE_IPV6 option in php-fpm

### DIFF
--- a/core/files/entrypoint_fpm.sh
+++ b/core/files/entrypoint_fpm.sh
@@ -83,8 +83,13 @@ change_php_vars() {
             sed -i -E "s/^pm.status_listen =/;pm.status_listen =/" "$FILE"
         fi
         if [[ -n "$PHP_LISTEN_FPM" ]]; then
-            echo "Configure PHP | Setting 'listen' to [::]:9002"
-            sed -i "/^listen =/s@=.*@= [::]:9002@" "$FILE"
+            if [[ "$DISABLE_IPV6" = "true" ]]; then
+                echo "Configure PHP | Setting 'listen' to 0.0.0.0:9002"
+                sed -i "/^listen =/s@=.*@= 0.0.0.0:9002@" "$FILE"
+            else
+                echo "Configure PHP | Setting 'listen' to [::]:9002"
+                sed -i "/^listen =/s@=.*@= [::]:9002@" "$FILE"
+            fi
         fi
 
     done


### PR DESCRIPTION
Copy the same DISABLE_IPV6 option present in the [nginx script][1] to php-fpm to allow the service to start when IPv6 is disable in the kernel

[1]: https://github.com/MISP/misp-docker/blob/master/core/files/entrypoint_nginx.sh#L388