### PR TITLE
Allow to disable the automatic rdb snapshot in valkey

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     restart: always
     command: |
       sh -c '
-        if [ "$${ENABLE_REDIS_SNAPSHOT}" = "false" ] ; then
+        if [ "$${DISABLE_REDIS_SNAPSHOT}" = "true" ] ; then
             redis_snapshot="--save \"\""
         else
             redis_snapshot=""
@@ -38,7 +38,7 @@ services:
       - "ENABLE_REDIS_EMPTY_PASSWORD=${ENABLE_REDIS_EMPTY_PASSWORD:-false}"
       - "REDIS_PASSWORD=${REDIS_PASSWORD:-redispassword}"
       - "TZ=${TZ:-UTC}"
-      - "ENABLE_REDIS_SNAPSHOT=${ENABLE_REDIS_SNAPSHOT:-true}"
+      - "DISABLE_REDIS_SNAPSHOT=${DISABLE_REDIS_SNAPSHOT:-false}"
     healthcheck:
       test: |
         sh -c '

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,16 +23,22 @@ services:
     restart: always
     command: |
       sh -c '
-        if [ "$${ENABLE_REDIS_EMPTY_PASSWORD:-false}" = "true" ]; then
-          exec valkey-server
+        if [ "$${ENABLE_REDIS_SNAPSHOT}" = "false" ] ; then
+            redis_snapshot="--save \"\""
         else
-          exec valkey-server --requirepass "$${REDIS_PASSWORD:-redispassword}"
+            redis_snapshot=""
+        fi
+        if [ "$${ENABLE_REDIS_EMPTY_PASSWORD:-false}" = "true" ]; then
+          exec valkey-server $${redis_snapshot}
+        else
+          exec valkey-server --requirepass "$${REDIS_PASSWORD:-redispassword}" $${redis_snapshot}
         fi
       '
     environment:
       - "ENABLE_REDIS_EMPTY_PASSWORD=${ENABLE_REDIS_EMPTY_PASSWORD:-false}"
       - "REDIS_PASSWORD=${REDIS_PASSWORD:-redispassword}"
       - "TZ=${TZ:-UTC}"
+      - "ENABLE_REDIS_SNAPSHOT=${ENABLE_REDIS_SNAPSHOT:-true}"
     healthcheck:
       test: |
         sh -c '

--- a/template.env
+++ b/template.env
@@ -146,6 +146,8 @@ SYNCSERVERS_1_PULL_RULES=
 # REDIS_PASSWORD=
 # Enable passwordless Redis connection (defaults to false for security)
 # ENABLE_REDIS_EMPTY_PASSWORD=false
+# Enable automatic snapshot dump to disk (defaults to true)
+# ENABLE_REDIS_SNAPSHOT=true
 
 # These variables allows overriding some MISP email values.
 # They all default to ADMIN_EMAIL.

--- a/template.env
+++ b/template.env
@@ -146,8 +146,8 @@ SYNCSERVERS_1_PULL_RULES=
 # REDIS_PASSWORD=
 # Enable passwordless Redis connection (defaults to false for security)
 # ENABLE_REDIS_EMPTY_PASSWORD=false
-# Enable automatic snapshot dump to disk (defaults to true)
-# ENABLE_REDIS_SNAPSHOT=true
+# Disable automatic snapshot dump to disk (defaults to false)
+# DISABLE_REDIS_SNAPSHOT=false
 
 # These variables allows overriding some MISP email values.
 # They all default to ADMIN_EMAIL.


### PR DESCRIPTION
By default, Valkey dumps regularly a snapshot, on testing/demo environnment, we may want to avoid the extra fs pressure