### PR TITLE
allow setting custom settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ docker-compose.override.yml
 .DS_Store
 .AppleDouble
 .LSOverride
+settings.json

--- a/README.md
+++ b/README.md
@@ -99,6 +99,23 @@ If you push a change to add or remove an environment variable, please look in "c
 
 The misp-core container has definitions for minimum safe default settings which are set if needed each time the container starts. They will only be set if there is no existing entry in the config.php file or database for these settings. If you specify a custom value for any of these settings it will be respected. See the definitions of these in "core/files/etc/misp-docker" where the filenames contain the word "defaults".
 
+#### Setting custom settings
+
+If you want to set custom MISP settings on startup please take the following steps:
+
+- create a `settings.json` file in the project root
+- uncomment the `settings.json` mountpoint in the `misp-core` image in `docker-compose.yml`
+- if you change the default mount path, be sure to update `MISP_SETTINGS_FILE` in your `.env` file
+- add the settings to your json
+
+##### Example
+
+```json
+{
+  "MISP.curl_request_timeout": "600"
+}
+```
+
 #### Storing system settings in the DB
 
 This container includes the "ENABLE_DB_SETTINGS" environment variable, which can be used to set "MISP.system_setting_db" to true or false. This changes the behaviour of where MISP chooses to store operator made settings changes; in config.php or in the system_settings database table. By default this is set to false.
@@ -229,7 +246,6 @@ LDAPAUTH_LDAPTLSPROTOCOLMIN=LDAP_OPT_X_TLS_PROTOCOL_TLS1_2
 STARTTLS is set to false as it's meant to upgrade an unencrypted connection (LDAP) to a secure one if possible automatically (LDAPS).
 As we use LDAPS (hardcoded) or no connection at all, this isn't desired.
 
-
 #### OIDC Authentication
 
 OIDC Auth is implemented through the MISP OidcAuth plugin.
@@ -313,7 +329,6 @@ CUSTOM_AUTH_CUSTOM_LOGOUT=
   - `./gnupg`: `/var/www/MISP/.gnupg/`
 - If you need to automatically run additional steps each time the container starts, create a new file `files/customize_misp.sh`, and replace the variable `${CUSTOM_PATH}` inside `docker-compose.yml` with its parent path.
 - If you are interested in running streamlined versions of the images (fewer dependencies, easier approval from compliance), you might want to use the `latest-slim` tag. Just adjust the `docker-compose.yml` file, and run again `docker compose pull` and `docker compose up`.
-
 
 ### High availability deployments
 

--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -28,14 +28,23 @@ init_workers() {
 
 set_misp_settings() {
     if [ -f "${MISP_SETTINGS_FILE}" ]; then
-        jq -c 'to_entries[]' "${MISP_SETTINGS_FILE}" | while read -r entry; do
+        # Validate that the settings file contains a JSON object before processing.
+        if ! jq -e 'type == "object"' "${MISP_SETTINGS_FILE}" >/dev/null 2>&1; then
+            echo "Error: ${MISP_SETTINGS_FILE} must contain a JSON object with key/value settings."
+            return 1
+        fi
+
+        # Capture jq output while checking its exit status so parse failures are not masked.
+        settings_entries=$(jq -c 'to_entries[]' "${MISP_SETTINGS_FILE}") || return 1
+
+        while IFS= read -r entry; do
             key=$(echo "$entry" | jq -r '.key')
             value=$(echo "$entry" | jq -r '.value')
 
             echo "Setting $key to $value"
 
             sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q "$key" "$value"
-        done
+        done <<< "$settings_entries"
     fi
 }
 

--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -26,6 +26,19 @@ init_workers() {
     stdbuf -oL supervisorctl start misp-workers:*
 }
 
+set_misp_settings() {
+    if [ -f "${MISP_SETTINGS_FILE}" ]; then
+        jq -c 'to_entries[]' "${MISP_SETTINGS_FILE}" | while read -r entry; do
+            key=$(echo "$entry" | jq -r '.key')
+            value=$(echo "$entry" | jq -r '.value')
+
+            echo "Setting $key to $value"
+
+            sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q "$key" "$value"
+        done
+    fi
+}
+
 configure_gnupg() {
     if [ "$AUTOCONF_GPG" != "true" ]; then
         echo "... GPG auto configuration disabled"
@@ -715,6 +728,8 @@ echo "MISP | Initialize workers ..." && init_workers
 echo "MISP | Apply DB updates ..." && apply_updates
 
 echo "MISP | Configure GPG key ..." && configure_gnupg
+
+echo "MISP | Set MISP settings ..." && set_misp_settings
 
 echo "MISP | Init default user and organization ..." && init_user
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,8 @@ services:
       - "./ssl/:/etc/nginx/certs/:Z"
       - "./gnupg/:/var/www/MISP/.gnupg/:Z"
       - "misp_guard_ca:/usr/local/share/ca-certificates/misp_guard:Z"
+      # custom MISP settings to be set on each boot, If changing the default path, be sure to also set MISP_SETTINGS_FILE
+      # - "./settings.json:/settings.json:ro"
     # customize by replacing ${CUSTOM_PATH} with a path containing 'files/customize_misp.sh'
     # - "${CUSTOM_PATH}/:/custom/:Z"
     # mount custom ca root certificates
@@ -334,6 +336,8 @@ services:
       - "CONTENT_SECURITY_POLICY=${CONTENT_SECURITY_POLICY}"
       # compose profiles
       - "COMPOSE_PROFILES=${COMPOSE_PROFILES}"
+      # MISP settings
+      - "MISP_SETTINGS_FILE=${MISP_SETTINGS_FILE:-/settings.json}"
 
   misp-modules:
     image: ${REGISTRY_MIRROR_URL:-}ghcr.io/misp/misp-docker/misp-modules:${MODULES_RUNNING_TAG:-latest}
@@ -357,7 +361,7 @@ services:
       - "./custom/expansion/:/custom/expansion/:Z"
       - "./custom/export_mod/:/custom/export_mod/:Z"
       - "./custom/import_mod/:/custom/import_mod/:Z"
-    environment:  
+    environment:
       - "TZ=${TZ:-UTC}"
 
   misp-guard:

--- a/template.env
+++ b/template.env
@@ -177,6 +177,9 @@ SYNCSERVERS_1_PULL_RULES=
 # Disable CA refresh
 # DISABLE_CA_REFRESH=true
 
+# Custom MISP settings
+# MISP_SETTINGS_FILE=/config/settings.json
+
 # Enable OIDC authentication, according to https://github.com/MISP/MISP/blob/2.5/app/Plugin/OidcAuth/README.md
 # OIDC_ENABLE=true
 # OIDC_PROVIDER_URL=
@@ -196,8 +199,8 @@ SYNCSERVERS_1_PULL_RULES=
 # OIDC_SKIP_PROXY=true
 
 # Enable LDAP (using the ApacheSecureAuth component) authentication, according to https://github.com/MISP/MISP/issues/6189
-# NOTE: Once you enable LDAP authentication with the ApacheSecureAuth component, 
-#	users should not be able to control the HTTP header configured in LDAP_APACHE_ENV 
+# NOTE: Once you enable LDAP authentication with the ApacheSecureAuth component,
+#	users should not be able to control the HTTP header configured in LDAP_APACHE_ENV
 #	(e.g. REMOTE_USER), this means you must not allow direct access to MISP.
 # NOTE 2: You need to escape special characters twice, e.g., "pass\word" becomes "pass\\\\word".
 # APACHESECUREAUTH_LDAP_ENABLE=true

--- a/template.env
+++ b/template.env
@@ -178,7 +178,7 @@ SYNCSERVERS_1_PULL_RULES=
 # DISABLE_CA_REFRESH=true
 
 # Custom MISP settings
-# MISP_SETTINGS_FILE=/config/settings.json
+# MISP_SETTINGS_FILE=/settings.json
 
 # Enable OIDC authentication, according to https://github.com/MISP/MISP/blob/2.5/app/Plugin/OidcAuth/README.md
 # OIDC_ENABLE=true


### PR DESCRIPTION
This allows for custom MISP settings at startup. Mounting a json file is way easier than putting a escaped json in the .env file