### PR TITLE
Add /var/www/MISP/app/Console to PATH

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -247,6 +247,8 @@ EOF
 
 FROM php-base
 
+ENV PATH="/var/www/MISP/app/Console:${PATH}"
+
 # Remove some defaults (kernel logging) and fix alternatives
 RUN sed -i '/imklog/s/^/#/' /etc/rsyslog.conf
 RUN update-alternatives --set php /usr/bin/php8.4


### PR DESCRIPTION
- /var/www/MISP/app/Console contains the cake CLI used for admin tasks
- Without it in PATH,  every docker exec admin command requires the full path
- Simple quality of life improvement