### PR TITLE
Return 404 for missing CSS assets instead of routing through CakePHP

### DIFF
--- a/core/files/etc/nginx/includes/misp
+++ b/core/files/etc/nginx/includes/misp
@@ -16,6 +16,10 @@ add_header X-Robots-Tag "none" always;
 fastcgi_hide_header X-Powered-By;
 server_tokens off;
 
+location ^~ /css/ {
+    try_files $uri =404;
+}
+
 location / {
     try_files $uri $uri/ /index.php$is_args$query_string;
 }


### PR DESCRIPTION
## Summary

This change ensures that missing CSS assets are handled by Nginx instead of being forwarded to CakePHP.

## Problem

The application was configured with:

```nginx
location / {
    try_files $uri $uri/ /index.php$is_args$query_string;
}
```

When a CSS-related asset (for example, a .css.map file) did not exist under /css/, the request fell through to index.php and was interpreted by CakePHP as an application route.

In practice, this caused asset requests to be treated as navigational URLs, which could interfere with authentication redirect logic and result in invalid login redirection behavior.

## Solution

Handle missing CSS asset requests at the web server level so they return a proper 404 Not Found response instead of being routed through CakePHP.

This is done by restricting /css/ to static file resolution only.

## Impact

* Missing CSS assets now return a correct 404 response
* CSS asset requests no longer reach CakePHP
* Prevents asset URLs from interfering with authentication redirect logic