### PR TITLE
Preserve custom logout URL when OIDC logout is configured

### DIFF
--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -393,7 +393,9 @@ set_up_custom_auth() {
         sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q "Plugin.CustomAuth_name" "External Authentication"
         sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q "Plugin.CustomAuth_disable_logout" false
         sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q -n "Plugin.CustomAuth_custom_password_reset"
-        sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q -n "Plugin.CustomAuth_custom_logout"
+        if [[ "$OIDC_ENABLE" != "true" || -z "${OIDC_LOGOUT_URL:-}" ]]; then
+            sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q -n "Plugin.CustomAuth_custom_logout"
+        fi
         # Re-enable settings
         sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q "Security.require_password_confirmation" true
         sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q "MISP.log_auth" true


### PR DESCRIPTION
## Summary

This change prevents `Plugin.CustomAuth_custom_logout` from being unintentionally removed when OIDC logout is enabled.

Fixes #409 

## Problem

`configure.sh` sets `Plugin.CustomAuth_custom_logout` when the required logout parameters are provided. However, later in the script the setting may be unset again when `CUSTOM_AUTH_ENABLE` is not enabled.

As a result, configurations that rely on OIDC logout can lose their custom logout URL even though it was configured correctly earlier in the script.

## Solution

Only unset `Plugin.CustomAuth_custom_logout` when OIDC logout is not enabled or when no OIDC logout URL has been provided.

This prevents the OIDC-specific logout configuration from being overwritten by the generic cleanup logic.

## Impact

* Preserves configured OIDC logout URLs.
* Prevents valid logout configuration from being removed later in the script.
* Makes the configuration logic consistent when OIDC is used without `CUSTOM_AUTH_ENABLE`.
