### PR TITLE
Make Supervisor creds available to docker exec sessions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -272,9 +272,9 @@ services:
       - "STUNNEL=${STUNNEL}"
       - "STUNNEL_CONFIG=${STUNNEL_CONFIG}"
       # supervisor settings
-      - "SUPERVISOR_HOST=${SUPERVISOR_HOST}"
-      - "SUPERVISOR_USERNAME=${SUPERVISOR_USERNAME}"
-      - "SUPERVISOR_PASSWORD=${SUPERVISOR_PASSWORD}"
+      - "SUPERVISOR_HOST=${SUPERVISOR_HOST:-127.0.0.1}"
+      - "SUPERVISOR_USERNAME=${SUPERVISOR_USERNAME:-supervisor}"
+      - "SUPERVISOR_PASSWORD=${SUPERVISOR_PASSWORD:-supervisor}"
       # sync server settings (see https://www.misp-project.org/openapi/#tag/Servers for more options)
       - "SYNCSERVERS=${SYNCSERVERS}"
       - |

--- a/template.env
+++ b/template.env
@@ -125,9 +125,9 @@ SYNCSERVERS_1_KEY=
 SYNCSERVERS_1_PULL_RULES=
 
 # optional, specify host and credentials for externally running supervisord
-# SUPERVISOR_HOST=
-# SUPERVISOR_USERNAME=
-# SUPERVISOR_PASSWORD=
+# SUPERVISOR_HOST=127.0.0.1
+# SUPERVISOR_USERNAME=supervisor
+# SUPERVISOR_PASSWORD=supervisor
 
 # optional and used to set mysql db and credentials
 # MYSQL_HOST=


### PR DESCRIPTION
`supervisorctl` cannot be used inside `misp-core` because the credentials are not exported.