### PR TITLE
fix: LDAP constants used in some LdapAuth settings are parsed as stri…

### DIFF
--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -224,6 +224,14 @@ set_up_ldap() {
         LDAPAUTH_LDAPTLSCUSTOMCACERT="\"$LDAPAUTH_LDAPTLSCUSTOMCACERT\""
     fi
 
+    # The LdapAuth plugin hands these three values straight to ldap_set_option(), which expects the
+    # integer value of the PHP constant. A constant name written as a string is silently coerced to 0
+    # (LDAP_OPT_X_TLS_NEVER / LDAP_OPT_X_TLS_CRL_NONE / no minimum protocol), so resolve the names to
+    # their integer values here and emit them unquoted below.
+    LDAPAUTH_LDAPTLSREQUIRECERT=$(resolve_php_constant "$LDAPAUTH_LDAPTLSREQUIRECERT") || exit 1
+    LDAPAUTH_LDAPTLSCRLCHECK=$(resolve_php_constant "$LDAPAUTH_LDAPTLSCRLCHECK") || exit 1
+    LDAPAUTH_LDAPTLSPROTOCOLMIN=$(resolve_php_constant "$LDAPAUTH_LDAPTLSPROTOCOLMIN") || exit 1
+
     sudo -u www-data php /var/www/MISP/tests/modify_config.php modify "{
         \"LdapAuth\": {
           \"ldapServer\": \"${LDAPAUTH_LDAPSERVER}\",
@@ -242,10 +250,10 @@ set_up_ldap() {
           \"ldapDefaultRoleId\": ${LDAPAUTH_LDAPDEFAULTROLEID},
           \"updateUser\": ${LDAPAUTH_UPDATEUSER},
           \"debug\": ${LDAPAUTH_DEBUG},
-          \"ldapTlsRequireCert\": \"${LDAPAUTH_LDAPTLSREQUIRECERT}\",
+          \"ldapTlsRequireCert\": ${LDAPAUTH_LDAPTLSREQUIRECERT},
           \"ldapTlsCustomCaCert\": ${LDAPAUTH_LDAPTLSCUSTOMCACERT},
-          \"ldapTlsCrlCheck\": \"${LDAPAUTH_LDAPTLSCRLCHECK}\",
-          \"ldapTlsProtocolMin\": \"${LDAPAUTH_LDAPTLSPROTOCOLMIN}\"
+          \"ldapTlsCrlCheck\": ${LDAPAUTH_LDAPTLSCRLCHECK},
+          \"ldapTlsProtocolMin\": ${LDAPAUTH_LDAPTLSPROTOCOLMIN}
        }
     }" > /dev/null
 

--- a/core/files/utilities.sh
+++ b/core/files/utilities.sh
@@ -110,3 +110,23 @@ init_settings() {
         set_default_settings "$settings_json" "$description"
     fi
 }
+
+# Resolve a PHP constant name (e.g. LDAP_OPT_X_TLS_ALLOW) to its integer value, so it can be written
+# as a number into config.php. Values that are already numeric are passed through unchanged.
+resolve_php_constant() {
+    local value="$1"
+
+    if [[ "$value" =~ ^-?[0-9]+$ ]]; then
+        echo "$value"
+        return 0
+    fi
+
+    local resolved
+    resolved=$(php -r 'echo defined($argv[1]) ? (int)constant($argv[1]) : "";' "$value")
+    if [ -z "$resolved" ]; then
+        echo "Unknown PHP constant: ${value}" >&2
+        return 1
+    fi
+
+    echo "$resolved"
+}


### PR DESCRIPTION
…ngs silently failing to do what they are supposed to

Add a utility function to parse php constants and write the integer value in the MISP config. 


Current settings in `template.env`:
```ini
LDAPAUTH_LDAPTLSREQUIRECERT="LDAP_OPT_X_TLS_ALLOW"
LDAPAUTH_LDAPTLSCRLCHECK="LDAP_OPT_X_TLS_CRL_PEER"
LDAPAUTH_LDAPTLSPROTOCOLMIN="LDAP_OPT_X_TLS_PROTOCOL_TLS1_2"
```

Produce:
```php
'ldapTlsRequireCert' => 'LDAP_OPT_X_TLS_ALLOW',
'ldapTlsCrlCheck' => 'LDAP_OPT_X_TLS_CRL_PEER',
'ldapTlsProtocolMin' => 'LDAP_OPT_X_TLS_PROTOCOL_TLS1_2',
```

Instead of:
```php
'ldapTlsRequireCert' => 3, // LDAP_OPT_X_TLS_ALLOW
'ldapTlsCrlCheck' => 1, // LDAP_OPT_X_TLS_CRL_PEER
'ldapTlsProtocolMin' => 771, // LDAP_OPT_X_TLS_PROTOCOL_TLS1_2
```