### PR TITLE
Pin OIDC phpseclib dependency version

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -110,6 +110,7 @@ RUN <<-EOF
                 elasticsearch/elasticsearch:^8.7.0 \
                 jakub-onderka/openid-connect-php:^1.0.0 \
                 certmichelin/openid-connect-php:1.3.0 \
+                phpseclib/phpseclib:^3.0.47 \
                 aws/aws-sdk-php
         fi
 EOF


### PR DESCRIPTION
Fixes #441

Pin the phpseclib used by certmichelin/openid-connect-php:1.3.0. 

Built and tested locally; confirmed it resolved the OIDC server 500 issue.

openid-connect-php uses phpseclib>=3.0.47 in their composer.json and now pulls 4.0.1, which is currently broken as documented in https://github.com/certmichelin/OpenID-Connect-PHP/pull/3

This can be backed out once certmichelin/openid-connect-php supports phpseclib 4.x

