### PR TITLE
fix: error out if certs are present but base url is non-https

### DIFF
--- a/nginx/files/01-listen.sh
+++ b/nginx/files/01-listen.sh
@@ -8,6 +8,16 @@ CONF="${NGINX_INCLUDE_DIR}/listen.conf"
 # ensure include file exists
 mkdir -p "${NGINX_INCLUDE_DIR}" && : > "$CONF"
 
+# error out if certs are present but base url is not https based
+if [ -f "/etc/nginx/certs/cert.pem" ] && [ -f "/etc/nginx/certs/key.pem" ]; then
+    case "$BASE_URL" in
+    http://*)
+        echo "BASE_URL starts with http://, but SSL certificate is present. Please update your env variables!"
+        exit 1
+        ;;
+    esac
+fi
+
 if [ -f "/etc/nginx/certs/cert.pem" ] && [ -f "/etc/nginx/certs/key.pem" ]; then
     # ipv4-ssl
     printf 'listen %s ssl;\n' "${NGINX_INTERNAL_HTTPS_PORT}" >> "$CONF"


### PR DESCRIPTION
Follow-up to #430.

If SSL certificate is present but the `BASE_URL` starts with `http://` error out.

Solution: `BASE_URL` needs to be updated to HTTPS.